### PR TITLE
adding interface to all upgradable contracts

### DIFF
--- a/contracts/ConversionRates.sol
+++ b/contracts/ConversionRates.sol
@@ -4,9 +4,9 @@ pragma solidity 0.4.18;
 import "./ERC20Interface.sol";
 import "./VolumeImbalanceRecorder.sol";
 import "./Utils.sol";
+import "./ConversionRatesInterface.sol";
 
-
-contract ConversionRates is VolumeImbalanceRecorder, Utils {
+contract ConversionRates is ConversionRatesInterface, VolumeImbalanceRecorder, Utils {
 
     // bps - basic rate steps. one step is 1 / 10000 of the rate.
     struct StepFunction {

--- a/contracts/ConversionRatesInterface.sol
+++ b/contracts/ConversionRatesInterface.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.4.18;
+
+
+import "./ERC20Interface.sol";
+
+
+interface ConversionRatesInterface {
+
+    function recordImbalance(
+        ERC20 token,
+        int buyAmount,
+        uint rateUpdateBlock,
+        uint currentBlock
+    )
+        public;
+
+    function getRate(ERC20 token, uint currentBlockNumber, bool buy, uint qty) public view returns(uint);
+}

--- a/contracts/ExpectedRate.sol
+++ b/contracts/ExpectedRate.sol
@@ -4,12 +4,7 @@ pragma solidity 0.4.18;
 import "./ERC20Interface.sol";
 import "./KyberNetwork.sol";
 import "./Withdrawable.sol";
-
-
-interface ExpectedRateInterface {
-    function getExpectedRate(ERC20 src, ERC20 dest, uint srcQty) public view
-        returns (uint expectedRate, uint slippageRate);
-}
+import "./ExpectedRateInterface.sol";
 
 
 contract ExpectedRate is Withdrawable, ExpectedRateInterface {

--- a/contracts/ExpectedRateInterface.sol
+++ b/contracts/ExpectedRateInterface.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.18;
+
+
+import "./ERC20Interface.sol";
+
+interface ExpectedRateInterface {
+    function getExpectedRate(ERC20 src, ERC20 dest, uint srcQty) public view
+        returns (uint expectedRate, uint slippageRate);
+}

--- a/contracts/FeeBurner.sol
+++ b/contracts/FeeBurner.sol
@@ -2,17 +2,13 @@ pragma solidity 0.4.18;
 
 
 import "./ERC20Interface.sol";
+import "./FeeBurnerInterface.sol";
 import "./Withdrawable.sol";
 
 
 interface BurnableToken {
     function transferFrom(address _from, address _to, uint _value) public returns (bool);
     function burnFrom(address _from, uint256 _value) public returns (bool);
-}
-
-
-interface FeeBurnerInterface {
-    function handleFees (uint tradeWeiAmount, address reserve, address wallet) public returns(bool);
 }
 
 

--- a/contracts/FeeBurnerInterface.sol
+++ b/contracts/FeeBurnerInterface.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.4.18;
+
+
+interface FeeBurnerInterface {
+    function handleFees (uint tradeWeiAmount, address reserve, address wallet) public returns(bool);
+}

--- a/contracts/KyberNetwork.sol
+++ b/contracts/KyberNetwork.sol
@@ -2,13 +2,13 @@ pragma solidity 0.4.18;
 
 
 import "./ERC20Interface.sol";
-import "./KyberReserve.sol";
+import "./KyberReserveInterface.sol";
 import "./Withdrawable.sol";
 import "./Utils.sol";
 import "./PermissionGroups.sol";
-import "./WhiteList.sol";
-import "./ExpectedRate.sol";
-import "./FeeBurner.sol";
+import "./WhiteListInterface.sol";
+import "./ExpectedRateInterface.sol";
+import "./FeeBurnerInterface.sol";
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -16,9 +16,9 @@ import "./FeeBurner.sol";
 contract KyberNetwork is Withdrawable, Utils {
 
     uint public negligibleRateDiff = 10; // basic rate steps will be in 0.01%
-    KyberReserve[] public reserves;
+    KyberReserveInterface[] public reserves;
     mapping(address=>bool) public isReserve;
-    WhiteList public whiteListContract;
+    WhiteListInterface public whiteListContract;
     ExpectedRateInterface public expectedRateContract;
     FeeBurnerInterface    public feeBurnerContract;
     uint                  public maxGasPrice = 50 * 1000 * 1000 * 1000; // 50 gwei
@@ -99,13 +99,13 @@ contract KyberNetwork is Withdrawable, Utils {
         return actualDestAmount;
     }
 
-    event AddReserveToNetwork(KyberReserve reserve, bool add);
+    event AddReserveToNetwork(KyberReserveInterface reserve, bool add);
 
     /// @notice can be called only by admin
     /// @dev add or deletes a reserve to/from the network.
     /// @param reserve The reserve address.
     /// @param add If true, the add reserve. Otherwise delete reserve.
-    function addReserve(KyberReserve reserve, bool add) public onlyAdmin {
+    function addReserve(KyberReserveInterface reserve, bool add) public onlyAdmin {
 
         if (add) {
             require(!isReserve[reserve]);
@@ -149,7 +149,7 @@ contract KyberNetwork is Withdrawable, Utils {
     }
 
     function setParams(
-        WhiteList _whiteList,
+        WhiteListInterface    _whiteList,
         ExpectedRateInterface _expectedRate,
         FeeBurnerInterface    _feeBurner,
         uint                  _maxGasPrice,
@@ -186,7 +186,7 @@ contract KyberNetwork is Withdrawable, Utils {
     /// @notice should be called off chain with as much gas as needed
     /// @dev get an array of all reserves
     /// @return An array of all reserves
-    function getReserves() public view returns(KyberReserve[]) {
+    function getReserves() public view returns(KyberReserveInterface[]) {
         return reserves;
     }
 
@@ -279,7 +279,7 @@ contract KyberNetwork is Withdrawable, Utils {
         uint rate;
 
         (reserveInd, rate) = findBestRate(src, dest, srcAmount);
-        KyberReserve theReserve = reserves[reserveInd];
+        KyberReserveInterface theReserve = reserves[reserveInd];
         require(rate > 0);
         require(rate < MAX_RATE);
         require(rate >= minConversionRate);
@@ -337,7 +337,7 @@ contract KyberNetwork is Withdrawable, Utils {
         ERC20 dest,
         address destAddress,
         uint expectedDestAmount,
-        KyberReserve reserve,
+        KyberReserveInterface reserve,
         uint conversionRate,
         bool validate
     )

--- a/contracts/KyberReserve.sol
+++ b/contracts/KyberReserve.sol
@@ -4,21 +4,22 @@ pragma solidity 0.4.18;
 import "./ERC20Interface.sol";
 import "./Utils.sol";
 import "./Withdrawable.sol";
-import "./ConversionRates.sol";
+import "./ConversionRatesInterface.sol";
 import "./VolumeImbalanceRecorder.sol";
-import "./SanityRates.sol";
+import "./SanityRatesInterface.sol";
+import "./KyberReserveInterface.sol";
 
 
 /// @title Kyber Reserve contract
-contract KyberReserve is Withdrawable, Utils {
+contract KyberReserve is KyberReserveInterface, Withdrawable, Utils {
 
     address public kyberNetwork;
     bool public tradeEnabled;
-    ConversionRates public conversionRatesContract;
+    ConversionRatesInterface public conversionRatesContract;
     SanityRatesInterface public sanityRatesContract;
     mapping(bytes32=>bool) public approvedWithdrawAddresses; // sha3(token,address)=>bool
 
-    function KyberReserve(address _kyberNetwork, ConversionRates _ratesContract, address _admin) public {
+    function KyberReserve(address _kyberNetwork, ConversionRatesInterface _ratesContract, address _admin) public {
         require(_admin != address(0));
         require(_ratesContract != address(0));
         require(_kyberNetwork != address(0));
@@ -104,7 +105,7 @@ contract KyberReserve is Withdrawable, Utils {
 
     event SetContractAddresses(address network, address rate, address sanity);
 
-    function setContracts(address _kyberNetwork, ConversionRates _conversionRates, SanityRatesInterface _sanityRates)
+    function setContracts(address _kyberNetwork, ConversionRatesInterface _conversionRates, SanityRatesInterface _sanityRates)
         public
         onlyAdmin
     {

--- a/contracts/KyberReserveInterface.sol
+++ b/contracts/KyberReserveInterface.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.4.18;
+
+
+import "./ERC20Interface.sol";
+
+/// @title Kyber Reserve contract
+interface KyberReserveInterface {
+
+    function trade(
+        ERC20 srcToken,
+        uint srcAmount,
+        ERC20 destToken,
+        address destAddress,
+        uint conversionRate,
+        bool validate
+    )
+        public
+        payable
+        returns(bool);
+
+    function getConversionRate(ERC20 src, ERC20 dest, uint srcQty, uint blockNumber) public view returns(uint);
+}

--- a/contracts/SanityRates.sol
+++ b/contracts/SanityRates.sol
@@ -4,11 +4,7 @@ pragma solidity 0.4.18;
 import "./ERC20Interface.sol";
 import "./Withdrawable.sol";
 import "./Utils.sol";
-
-
-interface SanityRatesInterface {
-    function getSanityRate(ERC20 src, ERC20 dest) public view returns(uint);
-}
+import "./SanityRatesInterface.sol";
 
 
 contract SanityRates is SanityRatesInterface, Withdrawable, Utils {

--- a/contracts/SanityRatesInterface.sol
+++ b/contracts/SanityRatesInterface.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.4.18;
+
+
+import "./ERC20Interface.sol";
+
+interface SanityRatesInterface {
+    function getSanityRate(ERC20 src, ERC20 dest) public view returns(uint);
+}

--- a/contracts/WhiteList.sol
+++ b/contracts/WhiteList.sol
@@ -2,9 +2,10 @@ pragma solidity 0.4.18;
 
 
 import "./Withdrawable.sol";
+import "./WhiteListInterface.sol";
 
 
-contract WhiteList is Withdrawable {
+contract WhiteList is WhiteListInterface, Withdrawable {
 
     uint public weiPerSgd; // amount of weis in 1 singapore dollar
     mapping (address=>uint) public userCategory; // each user has a category defining cap on trade. 0 for standard.

--- a/contracts/WhiteListInterface.sol
+++ b/contracts/WhiteListInterface.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.4.18;
+
+
+contract WhiteListInterface {
+    function getUserCapInWei(address user) external view returns (uint userCapWei);
+}

--- a/contracts/mockContracts/MockImbalanceRecorder.sol
+++ b/contracts/mockContracts/MockImbalanceRecorder.sol
@@ -43,7 +43,7 @@ contract MockImbalanceRecorder is VolumeImbalanceRecorder {
         int totalBuyUnitsImbalance,
         uint lastRateUpdateBlock
     )
-        external view returns(uint)
+        external pure returns(uint)
     {
         TokenImbalanceData memory data =
             TokenImbalanceData(lastBlockBuyUnitsImbalance, lastBlock, totalBuyUnitsImbalance, lastRateUpdateBlock);


### PR DESCRIPTION
adding interface to all upgradable contracts.
This will allow upgrading them without a need to change the binary of an unchanged contract.
Hence, it will be possible to use same deployed binaries when testing upgrades.
For example, if we change `KyberReserve.sol`, the binary of `KyberNetwork.sol` would have been change before.
As a result the deployed `KyberNetwork.sol` would have different binary than the one we use for testing.