### PR TITLE
Ilan/fee burner add tax capability

### DIFF
--- a/contracts/FeeBurner.sol
+++ b/contracts/FeeBurner.sol
@@ -28,9 +28,11 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
     address public kyberNetwork;
     uint public kncPerETHRate = 300;
 
-    function FeeBurner(address _admin, BurnableToken kncToken) public {
+    function FeeBurner(address _admin, BurnableToken kncToken, address _kyberNetwork) public {
         require(_admin != address(0));
         require(kncToken != address(0));
+        require(_kyberNetwork != address(0));
+        kyberNetwork = _kyberNetwork;
         admin = _admin;
         knc = kncToken;
     }
@@ -55,11 +57,6 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
     function setTaxWallet(address _taxWallet) public onlyAdmin {
         require(_taxWallet != address(0));
         taxWallet = _taxWallet;
-    }
-
-    function setKyberNetwork(address _kyberNetwork) public onlyAdmin {
-        require(_kyberNetwork != address(0));
-        kyberNetwork = _kyberNetwork;
     }
 
     function setKNCRate(uint rate) public onlyAdmin {

--- a/contracts/FeeBurner.sol
+++ b/contracts/FeeBurner.sol
@@ -19,7 +19,7 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
     mapping(address=>address) public reserveKNCWallet; //wallet holding knc per reserve. from here burn and send fees.
     mapping(address=>uint) public walletFeesInBps; // wallet that is the source of tx is entitled so some fees.
     mapping(address=>uint) public reserveFeeToBurn;
-    mapping(address=>uint) public feesPayedPerReserve; // track burned fees and sent wallet fees per reserve.
+    mapping(address=>uint) public feePayedPerReserve; // track burned fees and sent wallet fees per reserve.
     mapping(address=>mapping(address=>uint)) public reserveFeeToWallet;
     address public taxWallet;
     uint public taxFeeBps = 0; // burned fees are taxed. % out of burned fees.
@@ -114,7 +114,7 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
         require(knc.burnFrom(reserveKNCWallet[reserve], burnAmount - 1));
 
         //update reserve "payments" so far
-        feesPayedPerReserve[reserve] += (taxToSend + burnAmount - 1);
+        feePayedPerReserve[reserve] += (taxToSend + burnAmount - 1);
 
         BurnAssignedFees(reserve, msg.sender, (burnAmount - 1));
     }
@@ -128,7 +128,7 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
         reserveFeeToWallet[reserve][wallet] = 1; // leave 1 twei to avoid spikes in gas fee
         require(knc.transferFrom(reserveKNCWallet[reserve], wallet, feeAmount - 1));
 
-        feesPayedPerReserve[reserve] += (feeAmount - 1);
+        feePayedPerReserve[reserve] += (feeAmount - 1);
         SendWalletFees(wallet, reserve, msg.sender);
     }
 }

--- a/contracts/FeeBurner.sol
+++ b/contracts/FeeBurner.sol
@@ -16,10 +16,13 @@ interface BurnableToken {
 contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
 
     mapping(address=>uint) public reserveFeesInBps;
-    mapping(address=>address) public reserveKNCWallet;
-    mapping(address=>uint) public walletFeesInBps;
+    mapping(address=>address) public reserveKNCWallet; //wallet holding knc per reserve. from here burn and send fees.
+    mapping(address=>uint) public walletFeesInBps; // wallet that is the source of tx is entitled so some fees.
     mapping(address=>uint) public reserveFeeToBurn;
+    mapping(address=>uint) public feesPayedPerReserve; // track burned fees and sent wallet fees per reserve.
     mapping(address=>mapping(address=>uint)) public reserveFeeToWallet;
+    address public taxWallet;
+    uint public taxFeeBps = 0; // burned fees are taxed. % out of burned fees.
 
     BurnableToken public knc;
     address public kyberNetwork;
@@ -44,13 +47,23 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
         walletFeesInBps[wallet] = feesInBps;
     }
 
+    function setTaxInBps(uint _taxFeeBps) public onlyAdmin {
+        require(_taxFeeBps < 10000); // under 100%
+        taxFeeBps = _taxFeeBps;
+    }
+
+    function setTaxWallet(address _taxWallet) public onlyAdmin {
+        require(_taxWallet != address(0));
+        taxWallet = _taxWallet;
+    }
+
     function setKyberNetwork(address _kyberNetwork) public onlyAdmin {
         require(_kyberNetwork != address(0));
         kyberNetwork = _kyberNetwork;
     }
 
     function setKNCRate(uint rate) public onlyAdmin {
-        require(kncPerETHRate <= MAX_RATE);
+        require(rate <= MAX_RATE);
         kncPerETHRate = rate;
     }
 
@@ -82,16 +95,31 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
         return true;
     }
 
+
     // this function is callable by anyone
-    event BurnAssignedFees(address indexed reserve, address sender);
+    event BurnAssignedFees(address indexed reserve, address sender, uint quantity);
+    event SendTaxFee(address indexed reserve, address sender, address taxWallet, uint quantity);
 
     function burnReserveFees(address reserve) public {
         uint burnAmount = reserveFeeToBurn[reserve];
-        require(burnAmount > 1);
+        uint taxToSend = 0;
+        require(burnAmount > 2);
         reserveFeeToBurn[reserve] = 1; // leave 1 twei to avoid spikes in gas fee
+        if (taxWallet != address(0) && taxFeeBps != 0) {
+            taxToSend = (burnAmount - 1) * taxFeeBps / 10000;
+            require(burnAmount - 1 > taxToSend);
+            burnAmount -= taxToSend;
+            if (taxToSend > 0) {
+                require (knc.transferFrom(reserveKNCWallet[reserve], taxWallet, taxToSend));
+                SendTaxFee(reserve, msg.sender, taxWallet, taxToSend);
+            }
+        }
         require(knc.burnFrom(reserveKNCWallet[reserve], burnAmount - 1));
 
-        BurnAssignedFees(reserve, msg.sender);
+        //update reserve "payments" so far
+        feesPayedPerReserve[reserve] += (taxToSend + burnAmount - 1);
+
+        BurnAssignedFees(reserve, msg.sender, (burnAmount - 1));
     }
 
     event SendWalletFees(address indexed wallet, address reserve, address sender);
@@ -103,6 +131,7 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils {
         reserveFeeToWallet[reserve][wallet] = 1; // leave 1 twei to avoid spikes in gas fee
         require(knc.transferFrom(reserveKNCWallet[reserve], wallet, feeAmount - 1));
 
+        feesPayedPerReserve[reserve] += (feeAmount - 1);
         SendWalletFees(wallet, reserve, msg.sender);
     }
 }

--- a/scripts/deployment.js
+++ b/scripts/deployment.js
@@ -579,11 +579,9 @@ contract('Deployment', function(accounts) {
     });
   });
 
-
-
   it("create burning fees", function() {
     this.timeout(31000000);
-    return FeeBurner.new(accounts[0],kncInstance.address).then(function(instance){
+    return FeeBurner.new(accounts[0],kncInstance.address, network.address).then(function(instance){
         feeBurner = instance;
         return feeBurner.addOperator(accounts[0],{from:accounts[0]});
     }).then(function(result){
@@ -592,9 +590,6 @@ contract('Deployment', function(accounts) {
       // set fees for reserve
       // 0.25% from accounts
       return feeBurner.setReserveData(reserve.address,25, accounts[0]);
-    }).then(function(){
-      // set kyber network
-      return feeBurner.setKyberNetwork(network.address);
     }).then(function(){
       return feeBurner.setWalletFees(0,50);
     }).then(function(){

--- a/scripts/deployment.js
+++ b/scripts/deployment.js
@@ -597,7 +597,11 @@ contract('Deployment', function(accounts) {
       return feeBurner.setKyberNetwork(network.address);
     }).then(function(){
       return feeBurner.setWalletFees(0,50);
-    });
+    }).then(function(){
+      return feeBurner.setTaxInBps(2000);
+    })/*.then(function(){
+      return feeBurner.setTaxWallet(0); // zero address will revert
+    })*/;
   });
 
   it("create expected rate", function() {

--- a/test/expectedRate.js
+++ b/test/expectedRate.js
@@ -163,8 +163,7 @@ contract('ExpectedRates', function(accounts) {
         await network.addReserve(reserve1.address, true);
 
         //set contracts
-        feeBurner = await FeeBurner.new(admin, tokenAdd[0]);
-        feeBurner.setKyberNetwork(network.address);
+        feeBurner = await FeeBurner.new(admin, tokenAdd[0], network.address);
         let kgtToken = await TestToken.new("kyber genesis token", "KGT", 0);
         whiteList = await WhiteList.new(admin, kgtToken.address);
         await whiteList.addOperator(operator);

--- a/test/feeBurner.js
+++ b/test/feeBurner.js
@@ -11,11 +11,13 @@ let mockKyberNetwork;
 let mockReserve;
 let mockKNCWallet;
 let someExternalWallet;
+let taxWallet;
 let kncPerEtherRate = 200;
 let initialKNCWalletBalance = 10000000000;
 let burnFeeInBPS = 70;  //basic price steps
+let taxFeesInBPS = 30;
 let totalBPS = 10000;   //total price steps.
-
+let payedSoFar = 0; //track how much fees payed or burned so far.
 
 contract('FeeBurner', function(accounts) {
     it("should init globals and init feeburner Inst.", async function () {
@@ -24,6 +26,7 @@ contract('FeeBurner', function(accounts) {
         mockReserve = accounts[8];
         mockKNCWallet = accounts[7];
         someExternalWallet = accounts[6];
+        taxWallet = accounts[5];
         admin = accounts[0];
         //move funds to knc wallet
         kncToken = await TestToken.new("kyber", "KNC", 18);
@@ -37,7 +40,7 @@ contract('FeeBurner', function(accounts) {
         //set parameters in fee burner.
         await feeBurnerInst.setKNCRate(kncPerEtherRate);
         await feeBurnerInst.setKyberNetwork(mockKyberNetwork);
-        await feeBurnerInst.setReserveData(mockReserve, 70, mockKNCWallet);
+        await feeBurnerInst.setReserveData(mockReserve, burnFeeInBPS, mockKNCWallet);
 
         //allowance to fee burner to enable burning
         await kncToken.approve(feeBurnerInst.address, initialKNCWalletBalance / 10, {from: mockKNCWallet});
@@ -119,12 +122,30 @@ contract('FeeBurner', function(accounts) {
             catch(e){
                 assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
         }
+
+        try {
+            await feeBurnerInst.setTaxInBps(taxFeesInBPS , {from: mockReserve});
+            assert(false, "expected throw in line above..")
+        }
+            catch(e){
+                assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
+        }
+
+        try {
+            await feeBurnerInst.setTaxWallet(taxWallet , {from: mockReserve});
+            assert(false, "expected throw in line above..")
+        }
+            catch(e){
+                assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
+        }
     });
 
-    it("should test burn fee and handle fee calls success. See waiting fees zeroed.", async function () {
+    it("should test burn fee success. See waiting fees 'zeroed' (= 1).", async function () {
         let feesWaitingToBurn = await feeBurnerInst.reserveFeeToBurn(mockReserve);
         assert(feesWaitingToBurn.valueOf() > 1, "unexpected waiting to burn.");
 
+        waitingFees = await feeBurnerInst.reserveFeeToBurn(mockReserve);
+        payedSoFar += (1 * waitingFees.valueOf()) - 1;
         await feeBurnerInst.burnReserveFees(mockReserve);
 
         feesWaitingToBurn = await feeBurnerInst.reserveFeeToBurn(mockReserve);
@@ -133,11 +154,106 @@ contract('FeeBurner', function(accounts) {
         let waitingWalletFees = await feeBurnerInst.reserveFeeToWallet(mockReserve, someExternalWallet);
         assert(waitingWalletFees.valueOf() > 1, "unexpected waiting wallet fees.");
 
+        payedSoFar += (1 * waitingWalletFees.valueOf()) - 1;
         await feeBurnerInst.sendFeeToWallet(someExternalWallet, mockReserve);
 
         waitingWalletFees = await feeBurnerInst.reserveFeeToWallet(mockReserve, someExternalWallet);
         assert(waitingWalletFees.valueOf() == 1, "unexpected waiting wallet fees.");
     });
+
+    it("should set tax fee and and tax wallet and validate values.", async function () {
+        await feeBurnerInst.setTaxWallet(taxWallet);
+
+        rxTaxWallet = await feeBurnerInst.taxWallet();
+
+        assert.equal(rxTaxWallet.valueOf(), taxWallet, "invalid tax wallet address");
+
+        //see zero address blocked.
+        try {
+            await feeBurnerInst.setTaxWallet(0);
+            assert(false, "expected throw in line above..")
+        }
+            catch(e){
+                assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
+        }
+
+        assert.equal(rxTaxWallet.valueOf(), taxWallet, "invalid tax wallet address");
+
+        //set tax in BPS
+        await feeBurnerInst.setTaxInBps(taxFeesInBPS);
+
+        rxTaxFees = await feeBurnerInst.taxFeeBps();
+
+        assert.equal(rxTaxFees.valueOf(), taxFeesInBPS, "invalid tax fees BPS");
+    });
+
+
+    it("should test tax fees sent to wallet according to set fees.", async function () {
+        let tradeSize = 1000;
+
+        let taxWalletInitBalance =  await kncToken.balanceOf(taxWallet);
+
+        //first see with zero tax nothing sent.
+        await feeBurnerInst.setTaxWallet(taxWallet);
+        await feeBurnerInst.setTaxInBps(0);
+        await feeBurnerInst.handleFees(tradeSize, mockReserve, 0, {from: mockKyberNetwork});
+
+        let waitingFees = await feeBurnerInst.reserveFeeToBurn(mockReserve);
+        payedSoFar += (1 * waitingFees.valueOf()) - 1;
+
+        assert(waitingFees.valueOf() > 0);
+
+        await feeBurnerInst.burnReserveFees(mockReserve);
+
+        let taxWalletBalance = await kncToken.balanceOf(taxWallet);
+        assert.equal(taxWalletBalance.valueOf(), taxWalletInitBalance.valueOf());
+
+        //now with tax
+        await feeBurnerInst.setTaxInBps(taxFeesInBPS);
+        await feeBurnerInst.handleFees(tradeSize, mockReserve, 0, {from: mockKyberNetwork});
+
+        waitingFees = await feeBurnerInst.reserveFeeToBurn(mockReserve);
+        payedSoFar += (1 * waitingFees.valueOf()) - 1;
+        assert(waitingFees.valueOf() > 0);
+        await feeBurnerInst.burnReserveFees(mockReserve);
+
+        let taxWalletBalanceAfter = await kncToken.balanceOf(taxWallet);
+        let expectedBalance = waitingFees * taxFeesInBPS / totalBPS;
+        assert.equal(taxWalletBalanceAfter.valueOf(), Math.floor(expectedBalance));
+    });
+
+
+    it("should test tax fees behavior with smallest values.", async function () {
+        //first create 2 wei burn fee. which will be reverted.
+        const burnFeeInBPS = 50; //0.5%
+        await feeBurnerInst.setReserveData(mockReserve, burnFeeInBPS, mockKNCWallet);
+        let tradeSize = 1; // * eth to knc rate is the ref number.
+
+        await feeBurnerInst.handleFees(tradeSize, mockReserve, 0, {from: mockKyberNetwork});
+        let waitingFees = await feeBurnerInst.reserveFeeToBurn(mockReserve);
+        assert.equal(waitingFees.valueOf(), 2);
+
+        //see burn fails
+        try {
+            await feeBurnerInst.burnReserveFees(mockReserve);
+            assert(false, "expected throw in line above..")
+        }
+            catch(e){
+                assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
+        }
+
+        await feeBurnerInst.handleFees(tradeSize, mockReserve, 0, {from: mockKyberNetwork});
+        waitingFees = await feeBurnerInst.reserveFeeToBurn(mockReserve);
+        assert.equal(waitingFees.valueOf(), 3);
+
+        //on value 3 want to see tax wallet gets 0 fees.
+        let taxWalletInitBalance = await kncToken.balanceOf(taxWallet);
+        await feeBurnerInst.burnReserveFees(mockReserve);
+        payedSoFar += waitingFees - 1;
+        let taxWalletBalance = await kncToken.balanceOf(taxWallet);
+        assert.equal(taxWalletBalance.valueOf(), taxWalletInitBalance.valueOf());
+    });
+
 
     it("should test that when knc wallet (we burn from) is empty burn fee is reverted.", async function () {
         let initialWalletbalance = await kncToken.balanceOf(mockKNCWallet);
@@ -215,7 +331,6 @@ contract('FeeBurner', function(accounts) {
         await feeBurnerInst.setReserveData(mockReserve, 99, mockKNCWallet);
     });
 
-
     it("should test can't set wallet fees above 100% (10000 bps).", async function () {
         let highBpsfee = 10000;
 
@@ -228,6 +343,22 @@ contract('FeeBurner', function(accounts) {
 
         //see success
         await feeBurnerInst.setWalletFees(someExternalWallet, 9999);
+    });
+
+
+    it("should test can't fee taxes above 100% (10000 bps).", async function () {
+        let highBpsTax = 10000;
+        let validBpsTax = 9999;
+
+        try {
+            await feeBurnerInst.setTaxInBps(highBpsTax);
+            assert(false, "throw was expected in line above.")
+        } catch(e){
+            assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
+        }
+
+        //see success
+        await feeBurnerInst.setTaxInBps(validBpsTax);
     });
 
     it("should test burn fees reverted when balance is 'zeroed' == 1.", async function () {
@@ -253,6 +384,12 @@ contract('FeeBurner', function(accounts) {
         } catch(e){
             assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
         }
+    });
+
+    it("should verify payed so far on this reserve.", async function () {
+        let rxPayedSoFar = await feeBurnerInst.feesPayedPerReserve(mockReserve);
+
+        assert.equal(rxPayedSoFar.valueOf(), payedSoFar);
     });
 
 });

--- a/test/feeBurner.js
+++ b/test/feeBurner.js
@@ -35,11 +35,10 @@ contract('FeeBurner', function(accounts) {
         assert.equal(balance.valueOf(), initialKNCWalletBalance, "unexpected wallet balance.");
 
         //init fee burner
-        feeBurnerInst = await FeeBurner.new(admin, kncToken.address);
+        feeBurnerInst = await FeeBurner.new(admin, kncToken.address, mockKyberNetwork);
 
         //set parameters in fee burner.
         await feeBurnerInst.setKNCRate(kncPerEtherRate);
-        await feeBurnerInst.setKyberNetwork(mockKyberNetwork);
         await feeBurnerInst.setReserveData(mockReserve, burnFeeInBPS, mockKNCWallet);
 
         //allowance to fee burner to enable burning
@@ -101,14 +100,6 @@ contract('FeeBurner', function(accounts) {
     it("should test all set set functions rejected for non admin.", async function () {
         try {
             await feeBurnerInst.setKNCRate(500, {from: mockReserve});
-            assert(false, "expected throw in line above..")
-        }
-            catch(e){
-                assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
-        }
-
-        try {
-            await feeBurnerInst.setKyberNetwork(mockKyberNetwork, {from: mockReserve});
             assert(false, "expected throw in line above..")
         }
             catch(e){
@@ -279,29 +270,28 @@ contract('FeeBurner', function(accounts) {
         let feeBurnerTemp;
 
         try {
-            feeBurnerTemp =  await FeeBurner.new(admin, 0);
+            feeBurnerTemp =  await FeeBurner.new(admin, 0, mockKyberNetwork);
             assert(false, "throw was expected in line above.")
         } catch(e){
             assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
         }
 
         try {
-            feeBurnerTemp =  await FeeBurner.new(0, kncToken.address);
+            feeBurnerTemp =  await FeeBurner.new(0, kncToken.address, mockKyberNetwork);
             assert(false, "throw was expected in line above.")
         } catch(e){
             assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
         }
 
-        feeBurnerTemp =  await FeeBurner.new(admin, kncToken.address);
 
         try {
-            await feeBurnerTemp.setKyberNetwork(0);
+            feeBurnerTemp =  await FeeBurner.new(admin, kncToken.address, 0);
             assert(false, "throw was expected in line above.")
         } catch(e){
             assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
         }
 
-        await feeBurnerTemp.setKyberNetwork(mockKyberNetwork);
+        feeBurnerTemp =  await FeeBurner.new(admin, kncToken.address, mockKyberNetwork);
     });
 
     it("should test can't set bps fee > 1% (100 bps).", async function () {

--- a/test/feeBurner.js
+++ b/test/feeBurner.js
@@ -377,7 +377,7 @@ contract('FeeBurner', function(accounts) {
     });
 
     it("should verify payed so far on this reserve.", async function () {
-        let rxPayedSoFar = await feeBurnerInst.feesPayedPerReserve(mockReserve);
+        let rxPayedSoFar = await feeBurnerInst.feePayedPerReserve(mockReserve);
 
         assert.equal(rxPayedSoFar.valueOf(), payedSoFar);
     });

--- a/test/kyberNetwork.js
+++ b/test/kyberNetwork.js
@@ -234,8 +234,7 @@ contract('KyberNetwork', function(accounts) {
         await network.addReserve(reserve2.address, true);
 
         //set contracts
-        feeBurner = await FeeBurner.new(admin, tokenAdd[0]);
-        feeBurner.setKyberNetwork(network.address);
+        feeBurner = await FeeBurner.new(admin, tokenAdd[0], network.address);
         let kgtToken = await TestToken.new("kyber genesis token", "KGT", 0);
         whiteList = await WhiteList.new(admin, kgtToken.address);
         await whiteList.addOperator(operator);

--- a/web3deployment/deployment_script_input_kovan.json
+++ b/web3deployment/deployment_script_input_kovan.json
@@ -148,6 +148,8 @@
   "min expected rate slippage" : 300,
   "KNC wallet" : "0xBC33a1F908612640F2849b56b67a4De4d179C151",
   "KNC to ETH rate" : 300,
+  "tax fees bps": 0,
+  "tax wallet address": "",
   "valid duration block" : 24,
 
   "output filename" : "kovan.json"

--- a/web3deployment/deployment_script_input_mainnet.json
+++ b/web3deployment/deployment_script_input_mainnet.json
@@ -194,6 +194,8 @@
   "min expected rate slippage" : 300,
   "KNC wallet" : "0xBC33a1F908612640F2849b56b67a4De4d179C151",
   "KNC to ETH rate" : 300,
+  "tax fees bps": 0,
+  "tax wallet address": "",
   "valid duration block" : 60,
 
   "output filename" : "mainnet_production.json"

--- a/web3deployment/deployment_script_input_mainnet_stage.json
+++ b/web3deployment/deployment_script_input_mainnet_stage.json
@@ -149,6 +149,8 @@
   "min expected rate slippage" : 300,
   "KNC wallet" : "0xBC33a1F908612640F2849b56b67a4De4d179C151",
   "KNC to ETH rate" : 300,
+  "tax fees bps": 0,
+  "tax wallet address": "",
   "valid duration block" : 60,
 
   "output filename" : "mainnet.json"


### PR DESCRIPTION
this PR covers fee burner and deployment aspects.
still missing:
1. handing of tax parameters in verification script.
2. tax parameters in deployment output files 'mainnet_production.json' and staging.
3. deployment script for this contract alone. (no need to commit anyway)
4. how to create address for tax wallet for test environment (deployment.js)