### PR TITLE
liquidity: Move functions from liquidity formula test to helper.

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
-
+const Math = require('mathjs');
+const BigNumber = require('bignumber.js');
 
 module.exports.isRevertErrorMessage = function( error ) {
     if( error.message.search('invalid opcode') >= 0 ) return true;
@@ -51,4 +52,43 @@ function toHexString(byteArray) {
   return Array.from(byteArray, function(byte) {
     return ('0' + (byte & 0xFF).toString(16)).slice(-2);
   }).join('')
+};
+
+module.exports.absDiff = function(num1, num2) {
+    return _absDiff(num1,num2);
+}
+
+module.exports.checkAbsDiff = function(num1, num2, maxDiffInPercentage) {
+    const maxDiffBig = new BigNumber(maxDiffInPercentage);
+    const diff = _absDiff(num1,num2);
+    return (diff.div(num1)).lte(maxDiffInPercentage.div(100));
+};
+
+module.exports.exp = function(num1,num2) {
+    const num1Math = Math.bignumber(new BigNumber(num1).toString(10));
+    const num2Math = Math.bignumber(new BigNumber(num2).toString(10));
+
+    const result = Math.pow(num1Math,num2Math);
+
+    return new BigNumber(result.toString());
+};
+
+module.exports.ln = function(num) {
+    const numMath = Math.bignumber(new BigNumber(num).toString(10));
+
+    const result = Math.log(numMath);
+
+    return new BigNumber(result.toString());
+};
+
+function _absDiff(num1,num2) {
+    const bigNum1 = new BigNumber(num1);
+    const bigNum2 = new BigNumber(num2);
+
+    if(bigNum1.gt(bigNum2)) {
+        return bigNum1.minus(bigNum2);
+    }
+    else {
+        return bigNum2.minus(bigNum1);
+    }
 };

--- a/test/liquidityFormula.js
+++ b/test/liquidityFormula.js
@@ -1,49 +1,11 @@
 const Liquidity = artifacts.require("./LiquidityFormula.sol");
 
 const Helper = require("./helper.js");
-const Math = require('mathjs');
 const BigNumber = require('bignumber.js');
 
 const e = new BigNumber("2.7182818284590452353602874713527");
 
 let liquidityContract;
-
-function absDiff(num1,num2) {
-    const bigNum1 = new BigNumber(num1);
-    const bigNum2 = new BigNumber(num2);
-
-    if(bigNum1.gt(bigNum2)) {
-        return bigNum1.minus(bigNum2);
-    }
-    else {
-        return bigNum2.minus(bigNum1);
-    }
-}
-
-function checkAbsDiff(num1, num2, maxDiffInPercentage) {
-    const maxDiffBig = new BigNumber(maxDiffInPercentage);
-    const diff = absDiff(num1,num2);
-    return (diff.div(num1)).lte(maxDiffInPercentage.div(100));
-}
-
-function exp(num1,num2) {
-    const num1Math = Math.bignumber(new BigNumber(num1).toString(10));
-    const num2Math = Math.bignumber(new BigNumber(num2).toString(10));
-
-    const result = Math.pow(num1Math,num2Math);
-
-    return new BigNumber(result.toString());
-}
-
-function ln(num) {
-    const numMath = Math.bignumber(new BigNumber(num).toString(10));
-
-    const result = Math.log(numMath);
-
-    return new BigNumber(result.toString());
-}
-
-
 
 contract('FeeBurner', function(accounts) {
     it("deploy liquidity contract", async function () {
@@ -75,11 +37,11 @@ contract('FeeBurner', function(accounts) {
         const q = precision.mul(precision);
         const p = new BigNumber("121").mul(q.div(2**3));
 
-        const expectedResult = exp(e,new BigNumber(p).div(q)).mul(precision);
+        const expectedResult = Helper.exp(e,new BigNumber(p).div(q)).mul(precision);
         const result = await liquidityContract.exp(p,q,precision);
 
-        assert(checkAbsDiff(expectedResult,result,precision.div(0.001)),
-               "exp result diff is " + absDiff(expectedResult,result).toString(10));
+        assert(Helper.checkAbsDiff(expectedResult,result,precision.div(0.001)),
+               "exp result diff is " + Helper.absDiff(expectedResult,result).toString(10));
     });
 
 


### PR DESCRIPTION
This is so we can use these functions in other places as well, e.g in liquidity
conversion rate test.