### PR TITLE
OrderList: mark and detect deleted orders

### DIFF
--- a/contracts/permissionless/OrderList.sol
+++ b/contracts/permissionless/OrderList.sol
@@ -102,6 +102,11 @@ contract OrderList is PermissionGroups, OrderListInterface {
         Order storage order = orders[orderId];
         orders[order.prevId].nextId = order.nextId;
         orders[order.nextId].prevId = order.prevId;
+
+        // Mark deleted order
+        order.prevId = TAIL_ID;
+        order.nextId = HEAD_ID;
+
         return true;
     }
 
@@ -294,7 +299,11 @@ contract OrderList is PermissionGroups, OrderListInterface {
         Order storage prev = orders[prevId];
 
         // Make sure prev order is either HEAD or properly initialised.
-        if (prevId != HEAD_ID && (prev.prevId == 0 || prev.nextId == 0)) {
+        if (prevId != HEAD_ID && (
+                prev.prevId == 0 ||
+                prev.nextId == 0 ||
+                prev.prevId == TAIL_ID ||
+                prev.nextId == HEAD_ID)) {
             return false;
         }
 


### PR DESCRIPTION
Indicate deleted orders by setting their prev to TAIL and their next to 
HEAD.

Use this indication to refuse accepting them as hints.