### PR TITLE
Revert "Arbitrage check shifted to FeeBurner"

### DIFF
--- a/contracts/ExpectedRate.sol
+++ b/contracts/ExpectedRate.sol
@@ -12,6 +12,7 @@ contract ExpectedRate is Withdrawable, ExpectedRateInterface, Utils2 {
     KyberNetwork public kyberNetwork;
     uint public quantityFactor = 2;
     uint public worstCaseRateFactorInBps = 50;
+    uint constant UNIT_QTY_FOR_FEE_BURNER = 10 ** 18;
     ERC20 public knc;
 
     function ExpectedRate(KyberNetwork _kyberNetwork, ERC20 _knc, address _admin) public {
@@ -63,6 +64,13 @@ contract ExpectedRate is Withdrawable, ExpectedRateInterface, Utils2 {
             expectedRate = expectedRateSmallQty(src, dest, srcQty, usePermissionless);
         }
 
+        if (src == knc &&
+            dest == ETH_TOKEN_ADDRESS &&
+            srcQty == UNIT_QTY_FOR_FEE_BURNER )
+        {
+            if (checkKncArbitrageRate(expectedRate)) expectedRate = 0;
+        }
+
         if (expectedRate > MAX_RATE) return (0, 0);
 
         uint worstCaseSlippageRate = ((10000 - worstCaseRateFactorInBps) * expectedRate) / 10000;
@@ -71,6 +79,18 @@ contract ExpectedRate is Withdrawable, ExpectedRateInterface, Utils2 {
         }
 
         return (expectedRate, slippageRate);
+    }
+
+    function checkKncArbitrageRate(uint currentKncToEthRate) public view returns(bool) {
+        uint converseRate;
+        uint slippage;
+    	(converseRate, slippage) = getExpectedRate(ETH_TOKEN_ADDRESS, knc, UNIT_QTY_FOR_FEE_BURNER, true);
+
+        // if returned rate is 0, can't trust this arb test. assume we have arb
+        if(converseRate == 0) return true;
+
+        require(converseRate <= MAX_RATE && currentKncToEthRate <= MAX_RATE);
+        return ((converseRate * currentKncToEthRate) > (PRECISION ** 2));
     }
 
     //@dev for small src quantities dest qty might be 0, then returned rate is zero.

--- a/contracts/FeeBurner.sol
+++ b/contracts/FeeBurner.sol
@@ -90,14 +90,11 @@ contract FeeBurner is Withdrawable, FeeBurnerInterface, Utils3 {
         (kyberEthKncRate, ) = kyberNetwork.getExpectedRate(ETH_TOKEN_ADDRESS, ERC20(knc), (10 ** 18));
         (kyberKncEthRate, ) = kyberNetwork.getExpectedRate(ERC20(knc), ETH_TOKEN_ADDRESS, (10 ** 18));
 
-        // if returned rate is 0, can't trust this arb test. assume we have arb
-        require(kyberEthKncRate <= MAX_RATE && kyberKncEthRate <= MAX_RATE);
-
-        //check for internal arbitrage
-        require(kyberEthKncRate * kyberKncEthRate <= PRECISION ** 2);
         //check "reasonable" spread == diff not too big. rate wasn't tampered.
+        require(kyberEthKncRate * kyberKncEthRate < PRECISION ** 2 * 2);
         require(kyberEthKncRate * kyberKncEthRate > PRECISION ** 2 / 2);
 
+        require(kyberEthKncRate <= MAX_RATE);
         kncPerEthRatePrecision = kyberEthKncRate;
         KNCRateSet(kncPerEthRatePrecision, kyberEthKncRate, kyberKncEthRate, msg.sender);
     }

--- a/test/expectedRate.js
+++ b/test/expectedRate.js
@@ -665,6 +665,69 @@ contract('ExpectedRate', function(accounts) {
         assert.equal(myRate[1].valueOf(), 0, "expected rate should be 0");
     });
 
+    it("should verify knc arbitrage.", async function() {
+        const mockNetwork = await MockNetwork.new();
+        const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);
+
+        aRate = 1.2345;
+        const ethToKncRatePrecision = precisionUnits.mul(aRate * 1.01);
+        const kncToEthRatePrecision = precisionUnits.div(aRate);
+
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision);
+        await mockNetwork.setPairRate(kncAddress, ethAddress, kncToEthRatePrecision);
+
+        const feeBurnerQty = new BigNumber(10**18);
+
+        // check exact qty
+        const myRate1 = await tempExpectedRate.getExpectedRate(kncAddress,ethAddress,feeBurnerQty,true);
+        assert.equal(myRate1[0].valueOf(), 0, "expected 0 rate in arbitrage");
+        assert.equal(myRate1[1].valueOf(), 0, "expected 0 slippage rate in arbitrage");
+
+        // check different qty
+        const myRate2 = await tempExpectedRate.getExpectedRate(kncAddress,ethAddress,feeBurnerQty.plus(1),true);
+        assert.equal(myRate2[0].valueOf(), kncToEthRatePrecision.valueOf() * 1, "unexpected rate in arbitrage");
+
+        // check converse direction
+        const myRate3 = await tempExpectedRate.getExpectedRate(ethAddress,kncAddress,feeBurnerQty,true);
+        assert.equal(myRate3[0].valueOf(), ethToKncRatePrecision.valueOf() * 1, "expected 0 rate in arbitrage");
+
+        // set non arbitrage rates
+        const ethToKncRatePrecision2 = precisionUnits.mul(aRate);
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision2);
+
+        // check exact qty
+        const myRate4 = await tempExpectedRate.getExpectedRate(kncAddress,ethAddress,feeBurnerQty,true);
+        assert.equal(myRate4[0].valueOf(), kncToEthRatePrecision.valueOf() * 1, "expected rate in arbitrage");
+    });
+
+    it("should verify when knc arbitrage the check arbitrage function returns true. otherwise returns false.", async function() {
+        const mockNetwork = await MockNetwork.new();
+        const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);
+        await tempExpectedRate.addOperator(operator);
+        await tempExpectedRate.setQuantityFactor(1, {from: operator});
+
+        aRate = 1.2345;
+        const ethToKncRatePrecision = precisionUnits.mul(aRate * 1.01);
+        const kncToEthRatePrecision = precisionUnits.div(aRate);
+
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision);
+        await mockNetwork.setPairRate(kncAddress, ethAddress, kncToEthRatePrecision);
+
+        let hasArb =  await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision)
+
+        // check exact qty
+        assert.equal(hasArb, true, "Arbitrage should exist");
+
+        // set non arbitrage rates
+        const ethToKncRatePrecision2 = precisionUnits.mul(aRate - 0.0001);
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision2);
+
+        hasArb = await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision);
+
+        // check exact qty
+        assert.equal(hasArb, false, "Arbitrage shouldn't exist");
+    });
+
     it("make sure call to find best rate will revert when less then 1 mil gas. in 'NetworkFailingGetRate'", async function() {
         const network = await NetworkFailingGetRate.new();
 
@@ -735,6 +798,133 @@ contract('ExpectedRate', function(accounts) {
         assert.equal(rxKncToEth2[0].valueOf(), 0);
     });
 
+    it("should verify function 'checkKncArbitrage' will return true if get rate fails and reutrns zero rate to this function.", async function() {
+        // find best rate is called with assembly code. thus could fail without reverting. but for check arbitrage. rate 0 response means check can't happen.
+        // when setting knc rate in fee burner. in underlying calls findBestRate is called 3 times. if 3rd one fails (Ex: out of gas) returned value
+        // would be 0, in this case there is the problem with arbitrage check.
+        const network = await NetworkFailingGetRate.new();
+
+        const tempExpectedRate = await ExpectedRate.new(network.address, kncAddress, admin);
+        await tempExpectedRate.addOperator(operator);
+        await tempExpectedRate.setQuantityFactor(1, {from: operator});
+        await network.setExpectedRateContract(tempExpectedRate.address);
+
+        aRate = 1.2345;
+        const ethToKncRatePrecision = precisionUnits.mul(aRate - 0.01);
+        const kncToEthRatePrecision = precisionUnits.div(aRate);
+
+        await network.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision);
+        await network.setPairRate(kncAddress, ethAddress, kncToEthRatePrecision);
+
+        let rxEthToKnc = await network.getExpectedRate(ethAddress, kncAddress, 345);
+        let rxKncToEth = await network.getExpectedRate(kncAddress, ethAddress, 345);
+
+        let hasArb =  await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision)
+        assert.equal(hasArb, false, "Arbitrage shouldn't exist");
+
+        hasArb =  await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision, {gas: 990000})
+        // here network should revert and get rate should avoid the revert and return 0
+        assert.equal(hasArb, true, "Arbitrage should exist");
+    });
+
+    it("should verify when no knc arbitrage set knc rate success. when have knc arb. set rate reverts.", async function() {
+        const mockNetwork = await NetworkFailingGetRate.new();
+        const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);
+        await tempExpectedRate.addOperator(operator);
+        await tempExpectedRate.setQuantityFactor(1, {from: operator});
+        await mockNetwork.setExpectedRateContract(tempExpectedRate.address);
+
+        const tempFeeBurner = await FeeBurner.new(admin, kncAddress, mockNetwork.address, 550 * 10 ** 18);
+        aRate = 1.2345;
+        const ethToKncRatePrecision = precisionUnits.mul(aRate * 1.01);
+        const kncToEthRatePrecision = precisionUnits.div(aRate);
+
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision);
+        await mockNetwork.setPairRate(kncAddress, ethAddress, kncToEthRatePrecision);
+
+        let rxEthToKnc = await mockNetwork.getExpectedRate(ethAddress, kncAddress, 10 ** 19);
+        let rxKncToEth = await mockNetwork.getExpectedRate(kncAddress, ethAddress, 10 ** 19);
+        assert.equal(rxEthToKnc[0].valueOf(), ethToKncRatePrecision.floor().valueOf())
+        assert.equal(rxKncToEth[0].valueOf(), kncToEthRatePrecision.floor().valueOf())
+
+        //when checking this qty and arb exists. will return 0
+        rxKncToEth = await mockNetwork.getExpectedRate(kncAddress, ethAddress, 10 ** 18);
+        assert.equal(rxKncToEth[0].valueOf(), 0)
+
+        let hasArb =  await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision)
+
+        assert.equal(hasArb, true, "Arbitrage should exist");
+
+        let burnerInitialkncRate = await tempFeeBurner.kncPerEthRatePrecision();
+//         has arb. get rate will return 0. should revert.
+        try {
+            let rxx = await tempFeeBurner.setKNCRate();
+            assert(false, "throw was expected in line above.")
+        } catch(e){
+            assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
+        }
+
+        let burnerkncRateAfterSet = await tempFeeBurner.kncPerEthRatePrecision();
+        assert.equal(burnerkncRateAfterSet.valueOf(), burnerInitialkncRate.valueOf());
+
+        // set non arbitrage rates
+        const ethToKncRatePrecision2 = precisionUnits.mul(aRate - 0.0001);
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision2);
+
+        hasArb = await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision);
+
+        // check exact qty
+        assert.equal(hasArb, false, "Arbitrage shouldn't exist");
+
+        rxEthToKnc = await mockNetwork.getExpectedRate(ethAddress, kncAddress, 10 ** 18);
+        rxKncToEth = await mockNetwork.getExpectedRate(kncAddress, ethAddress, 10 ** 18);
+
+        assert.equal(rxEthToKnc[0].valueOf(), ethToKncRatePrecision2.floor().valueOf())
+        assert.equal(rxKncToEth[0].valueOf(), kncToEthRatePrecision.floor().valueOf())
+
+        // no arb. set rate should not fail
+        let rx = await tempFeeBurner.setKNCRate();
+        burnerkncRateAfterSet = await tempFeeBurner.kncPerEthRatePrecision();
+        assert.equal(ethToKncRatePrecision2.valueOf(), burnerkncRateAfterSet.valueOf());
+    });
+
+    it("should verify function 'setKncRate' will fail if last call to findBestRate fails.", async function() {
+        const mockNetwork = await NetworkFailingGetRate.new();
+        const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);
+        await tempExpectedRate.addOperator(operator);
+        await tempExpectedRate.setQuantityFactor(1, {from: operator});
+        await mockNetwork.setExpectedRateContract(tempExpectedRate.address);
+
+        const tempFeeBurner = await FeeBurner.new(admin, kncAddress, mockNetwork.address, 550 * 10 ** 18);
+        aRate = 1.2345;
+        const ethToKncRatePrecision = precisionUnits.mul(aRate - 0.001);
+        const kncToEthRatePrecision = precisionUnits.div(aRate);
+
+        await mockNetwork.setPairRate(ethAddress, kncAddress, ethToKncRatePrecision);
+        await mockNetwork.setPairRate(kncAddress, ethAddress, kncToEthRatePrecision);
+
+        let hasArb =  await tempExpectedRate.checkKncArbitrageRate(kncToEthRatePrecision)
+
+        assert.equal(hasArb, false, "Arbitrage shouldn't exist");
+
+        let burnerInitialkncRate = await tempFeeBurner.kncPerEthRatePrecision();
+
+        ///set knc rate with less then 3 milion gas - should fail and revert
+        try {
+            let rxx = await tempFeeBurner.setKNCRate({gas: 2800000});
+            assert(false, "throw was expected in line above.")
+        } catch(e){
+            assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
+        }
+
+        let burnerkncRateAfterSet = await tempFeeBurner.kncPerEthRatePrecision();
+        assert.equal(burnerkncRateAfterSet.valueOf(), burnerInitialkncRate.valueOf());
+
+        await tempFeeBurner.setKNCRate({gas: 3500000});
+        burnerkncRateAfterSet = await tempFeeBurner.kncPerEthRatePrecision();
+        assert.equal(ethToKncRatePrecision.valueOf(), burnerkncRateAfterSet.valueOf());
+    });
+
     it("call getExpectedRate call to kyber reverts. getExpectedRate should return 0 and not revert. without permissionless", async() => {
         const mockNetwork = await MockNetwork.new();
         const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);
@@ -775,7 +965,7 @@ contract('ExpectedRate', function(accounts) {
         assert.equal(rates[0].valueOf(), 0, "unexpected rate");
         assert.equal(rates[1].valueOf(), 0, "unexpected rate");
     })
-
+    
     it("call getExpectedRate call to kyber reverts. getExpectedRate should return 0 and not revert. including permissionless", async() => {
         const mockNetwork = await MockNetwork.new();
         const tempExpectedRate = await ExpectedRate.new(mockNetwork.address, kncAddress, admin);

--- a/test/feeBurner.js
+++ b/test/feeBurner.js
@@ -1,8 +1,6 @@
 const FeeBurner = artifacts.require("FeeBurner.sol");
 const TestToken = artifacts.require("TestToken.sol");
 const MockKyberNetwork = artifacts.require("MockKyberNetwork.sol");
-const NetworkFailingGetRate = artifacts.require("NetworkFailingGetRate.sol");
-const ExpectedRate = artifacts.require("ExpectedRate.sol");
 const MockUtils = artifacts.require("MockUtils.sol");
 
 const Helper = require("./helper.js");
@@ -15,20 +13,19 @@ const precision = new BigNumber(10 ** 18);
 let kncToken;
 let feeBurnerInst;
 let mockKyberNetwork;
+let mockNetwork;
 let mockReserve;
 let someReserve;
 let mockKNCWallet;
 let someExternalWallet;
 let taxWallet;
 let kncPerEthRatePrecision = precision.mul(210);
-let precisionUnits = (new BigNumber(10).pow(18));
 let initialKNCWalletBalance = 10000000000;
 let burnFeeInBPS = 70;  //basic price steps
 let taxFeesInBPS = 30;
 let totalBPS = 10000;   //total price steps.
 let payedSoFar = 0; //track how much fees payed or burned so far.
 let MAX_RATE;
-let aRate;
 
 //accounts
 let admin;
@@ -489,10 +486,10 @@ contract('FeeBurner', function(accounts) {
     it("should test set knc rate gets rate from kyber network", async function () {
  //init mock kyber network and set knc rate
 //        log("create mock")
-        let ethKncRate = 431;
+        ethKncRate = 431;
         mockKyberNetwork = await MockKyberNetwork.new();
         let ethToKncRatePrecision = precision.mul(ethKncRate);
-        let kncToEthRatePrecision = precision.div(ethKncRate).floor();
+        let kncToEthRatePrecision = precision.div(ethKncRate);
 
 //        log("set pair rate")
         await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision);
@@ -501,13 +498,12 @@ contract('FeeBurner', function(accounts) {
         let rate = await mockKyberNetwork.getExpectedRate(ethAddress, kncToken.address, (10 ** 18));
         assert.equal(ethToKncRatePrecision.valueOf(), rate[0].valueOf());
         rate = await mockKyberNetwork.getExpectedRate(kncToken.address, ethAddress, (10 ** 18));
-        assert.equal(kncToEthRatePrecision.valueOf(), rate[0].valueOf());
+        assert.equal(kncToEthRatePrecision.add(1).floor().valueOf(), rate[0].valueOf());
 
         //init fee burner
         feeBurnerInst = await FeeBurner.new(admin, kncToken.address, mockKyberNetwork.address, kncPerEthRatePrecision);
         await feeBurnerInst.addOperator(operator, {from: admin});
 
-        let totalRate = ethToKncRatePrecision.mul(kncToEthRatePrecision);
         await feeBurnerInst.setKNCRate();
         let rxKncRate = await feeBurnerInst.kncPerEthRatePrecision()
         assert.equal(rxKncRate.valueOf(), ethToKncRatePrecision.valueOf());
@@ -521,7 +517,7 @@ contract('FeeBurner', function(accounts) {
         let oldRate = ethToKncRatePrecision;
         kncPerEthRatePrecision = 1000;
         ethToKncRatePrecision = precision.mul(kncPerEthRatePrecision);
-        kncToEthRatePrecision = precision.div(kncPerEthRatePrecision).floor();
+        kncToEthRatePrecision = precision.div(kncPerEthRatePrecision);
         await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision);
         await mockKyberNetwork.setPairRate(kncToken.address, ethAddress, kncToEthRatePrecision);
 
@@ -617,8 +613,16 @@ contract('FeeBurner', function(accounts) {
             assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
         }
 
-        //reasonable spread
-        kncPerEthRatePrecisionWSpread = (new BigNumber(kncPerEthRatePrecision * 0.75)).floor();
+        kncPerEthRatePrecisionWSpread = (new BigNumber(kncPerEthRatePrecision * 1.99999)).floor();
+        ethToKncRatePrecision = precision.mul(kncPerEthRatePrecisionWSpread);
+
+        await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision);
+        let rate = await mockKyberNetwork.getExpectedRate(ethAddress, kncToken.address, (10 ** 18));
+        assert.equal(ethToKncRatePrecision.valueOf(), rate[0].valueOf());
+
+        let rc = await feeBurnerInst.setKNCRate();
+
+        kncPerEthRatePrecisionWSpread = (new BigNumber(kncPerEthRatePrecision * 0.6)).floor();
         kncToEthRatePrecision = precision.div(kncPerEthRatePrecision).floor();
         ethToKncRatePrecision = precision.mul(kncPerEthRatePrecisionWSpread);
 
@@ -640,62 +644,9 @@ contract('FeeBurner', function(accounts) {
             assert(Helper.isRevertErrorMessage(e), "expected throw but got other error: " + e);
         }
     });
-
-    it("should verify when have knc arbitrage, set rate reverts.", async function() {
-        aRate = 1.2345;
-        const ethToKncRatePrecision = precisionUnits.mul(aRate * 1.01);
-        const kncToEthRatePrecision = precisionUnits.div(aRate);
-
-        await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision);
-        await mockKyberNetwork.setPairRate(kncToken.address, ethAddress, kncToEthRatePrecision);
-
-        let rxEthToKnc = await mockKyberNetwork.getExpectedRate(ethAddress, kncToken.address, 10 ** 19);
-        let rxKncToEth = await mockKyberNetwork.getExpectedRate(kncToken.address, ethAddress, 10 ** 19);
-        assert.equal(rxEthToKnc[0].valueOf(), ethToKncRatePrecision.floor().valueOf())
-        assert.equal(rxKncToEth[0].valueOf(), kncToEthRatePrecision.floor().valueOf())
-
-        let burnerInitialkncRate = await feeBurnerInst.kncPerEthRatePrecision();
-//         has arb. get rate will return 0. should revert.
-        try {
-            let rxx = await feeBurnerInst.setKNCRate();
-            assert(false, "throw was expected in line above.")
-        } catch(e){
-            assert(Helper.isRevertErrorMessage(e), "expected throw but got: " + e);
-        }
-
-        let burnerkncRateAfterSet = await feeBurnerInst.kncPerEthRatePrecision();
-        assert.equal(burnerkncRateAfterSet.valueOf(), burnerInitialkncRate.valueOf());
-      });
-
-      it("should verify when have no knc arbitrage, set rate success", async function() {
-        aRate = 1.2345;
-        const ethToKncRatePrecision = precisionUnits.mul(aRate * 1.01);
-        const kncToEthRatePrecision = precisionUnits.div(aRate);
-
-        await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision);
-        await mockKyberNetwork.setPairRate(kncToken.address, ethAddress, kncToEthRatePrecision);
-
-        let rxEthToKnc = await mockKyberNetwork.getExpectedRate(ethAddress, kncToken.address, 10 ** 19);
-        let rxKncToEth = await mockKyberNetwork.getExpectedRate(kncToken.address, ethAddress, 10 ** 19);
-        assert.equal(rxEthToKnc[0].valueOf(), ethToKncRatePrecision.floor().valueOf())
-        assert.equal(rxKncToEth[0].valueOf(), kncToEthRatePrecision.floor().valueOf())
-
-        // set non arbitrage rates
-        const ethToKncRatePrecision2 = precisionUnits.mul(aRate - 0.0001);
-        await mockKyberNetwork.setPairRate(ethAddress, kncToken.address, ethToKncRatePrecision2);
-
-        rxEthToKnc = await mockKyberNetwork.getExpectedRate(ethAddress, kncToken.address, 10 ** 18);
-        rxKncToEth = await mockKyberNetwork.getExpectedRate(kncToken.address, ethAddress, 10 ** 18);
-
-        assert.equal(rxEthToKnc[0].valueOf(), ethToKncRatePrecision2.floor().valueOf())
-        assert.equal(rxKncToEth[0].valueOf(), kncToEthRatePrecision.floor().valueOf())
-
-        // no arb. set rate should not fail
-        let rx = await feeBurnerInst.setKNCRate();
-        burnerkncRateAfterSet = await feeBurnerInst.kncPerEthRatePrecision();
-        assert.equal(ethToKncRatePrecision2.valueOf(), burnerkncRateAfterSet.valueOf());
-    });
 });
+
+
 
 function log(str) {
     console.log(str);

--- a/test/kyberNetwork.js
+++ b/test/kyberNetwork.js
@@ -2809,13 +2809,14 @@ contract('KyberNetwork', function(accounts) {
             let srcAmountTwei = 136;
             let maxDestAmount = (new BigNumber(10)).pow(18);
 
-            buyRate = await network.getExpectedRate(tokenSrc.address, tokenDest.address, srcAmountTwei.valueOf());
-            assert.equal(buyRate[0].valueOf(), 0, "Rate returned is not zero for same src & dst token");
+            rate = await network.getExpectedRate(tokenSrc.address, tokenDest.address, srcAmountTwei.valueOf());
 
             let ethBalance = await Helper.getBalancePromise(reserve1.address);
             ethBalance = await Helper.getBalancePromise(reserve2.address);
             let destTokBalance = await tokenDest.balanceOf(reserve1.address)
             destTokBalance = await tokenDest.balanceOf(reserve2.address)
+
+            let expectedDestAmount = calcDstQty(srcAmountTwei, tokenDecimals[tokenSrcInd], tokenDecimals[tokenDestInd], rate[0]);
 
             await tokenSrc.transfer(user1, srcAmountTwei);
             await tokenSrc.approve(networkProxy, srcAmountTwei, {from:user1})

--- a/test/kyberNetwork.js
+++ b/test/kyberNetwork.js
@@ -2809,14 +2809,13 @@ contract('KyberNetwork', function(accounts) {
             let srcAmountTwei = 136;
             let maxDestAmount = (new BigNumber(10)).pow(18);
 
-            rate = await network.getExpectedRate(tokenSrc.address, tokenDest.address, srcAmountTwei.valueOf());
+            buyRate = await network.getExpectedRate(tokenSrc.address, tokenDest.address, srcAmountTwei.valueOf());
+            assert.equal(buyRate[0].valueOf(), 0, "Rate returned is not zero for same src & dst token");
 
             let ethBalance = await Helper.getBalancePromise(reserve1.address);
             ethBalance = await Helper.getBalancePromise(reserve2.address);
             let destTokBalance = await tokenDest.balanceOf(reserve1.address)
             destTokBalance = await tokenDest.balanceOf(reserve2.address)
-
-            let expectedDestAmount = calcDstQty(srcAmountTwei, tokenDecimals[tokenSrcInd], tokenDecimals[tokenDestInd], rate[0]);
 
             await tokenSrc.transfer(user1, srcAmountTwei);
             await tokenSrc.approve(networkProxy, srcAmountTwei, {from:user1})


### PR DESCRIPTION
Reverts KyberNetwork/smart-contracts#433

was decided not to include this in next deploy
will be delayed.