### PR TITLE
zero srcQty handling

### DIFF
--- a/contractsSol5/KyberNetwork.sol
+++ b/contractsSol5/KyberNetwork.sol
@@ -279,13 +279,12 @@ contract KyberNetwork is Withdrawable2, Utils4, IKyberNetwork, ReentrancyGuard {
     {
         if (src == dest) return (0, 0);
         uint qty = srcQty & ~PERM_HINT_GET_RATE;
-        if (qty == 0) qty = 1;
 
         TradeData memory tData = initTradeInput({
             trader: address(uint160(0)),
             src: src,
             dest: dest,
-            srcAmount: qty,
+            srcAmount: (qty == 0) ? 1 : qty,
             destAddress: address(uint160(0)),
             maxDestAmount: 2 ** 255,
             minConversionRate: 0,

--- a/contractsSol5/KyberNetwork.sol
+++ b/contractsSol5/KyberNetwork.sol
@@ -279,6 +279,7 @@ contract KyberNetwork is Withdrawable2, Utils4, IKyberNetwork, ReentrancyGuard {
     {
         if (src == dest) return (0, 0);
         uint qty = srcQty & ~PERM_HINT_GET_RATE;
+        if (qty == 0) qty = 1;
 
         TradeData memory tData = initTradeInput({
             trader: address(uint160(0)),
@@ -301,12 +302,13 @@ contract KyberNetwork is Withdrawable2, Utils4, IKyberNetwork, ReentrancyGuard {
     }
 
     // new APIs
-    function getExpectedRateWithHintAndFee(IERC20 src, IERC20 dest, uint srcQty, uint platformFeeBps, bytes calldata hint) 
-        external view
+    function getExpectedRateWithHintAndFee(IERC20 src, IERC20 dest, uint srcQty, uint platformFeeBps, bytes memory hint) 
+        public view
         returns (uint rateNoFees, uint rateAfterNetworkFee, uint rateAfterAllFees)
     {
         if (src == dest) return (0, 0, 0);
-        
+        if (srcQty == 0) srcQty = 1;
+
         TradeData memory tData = initTradeInput({
             trader: address(uint160(0)),
             src: src,

--- a/test/sol5/kyberNetwork.js
+++ b/test/sol5/kyberNetwork.js
@@ -332,8 +332,7 @@ contract('KyberNetwork', function(accounts) {
             let fakeProxy = accounts[3];
             let txResult = await tempNetwork.addKyberProxy(fakeProxy, {from: admin});
             expectEvent(txResult, 'KyberProxyAdded', {
-                proxy: fakeProxy,
-                sender: admin
+                proxy: fakeProxy
             });
         });
 
@@ -554,14 +553,23 @@ contract('KyberNetwork', function(accounts) {
             });
 
             it("should return rates for zero srcQty", async() => {
+                let modifiedSrcQty = new BN(1);
+                info = [modifiedSrcQty, networkFeeBps, platformFee];
+                
+                expectedResult = await matchingEngine.calcRatesAndAmounts(srcToken.address, ethAddress, srcDecimals, ethDecimals, info, emptyHint);
+                expectedResult = await nwHelper.unpackRatesAndAmounts(info, srcDecimals, ethDecimals, expectedResult);
                 actualResult = await network.getExpectedRate(srcToken.address, ethAddress, zeroBN);
-                Helper.assertEqual(expectedResult.rateAfterNetworkFee, zeroBN, "expected rate with network fee != actual rate for T2E");
+                Helper.assertEqual(expectedResult.rateAfterNetworkFee, actualResult.expectedRate, "expected rate with network fee != actual rate for T2E");
         
+                expectedResult = await matchingEngine.calcRatesAndAmounts(ethAddress, destToken.address, ethDecimals, destDecimals, info, emptyHint);
+                expectedResult = await nwHelper.unpackRatesAndAmounts(info, ethDecimals, destDecimals, expectedResult);
                 actualResult = await network.getExpectedRate(ethAddress, destToken.address, zeroBN);
-                Helper.assertEqual(expectedResult.rateAfterNetworkFee, zeroBN, "expected rate with network fee != actual rate for E2T");
+                Helper.assertEqual(expectedResult.rateAfterNetworkFee, actualResult.expectedRate, "expected rate with network fee != actual rate for E2T");
 
+                expectedResult = await matchingEngine.calcRatesAndAmounts(srcToken.address, destToken.address, srcDecimals, destDecimals, info, emptyHint);
+                expectedResult = await nwHelper.unpackRatesAndAmounts(info, srcDecimals, destDecimals, expectedResult);
                 actualResult = await network.getExpectedRate(srcToken.address, destToken.address, zeroBN);
-                Helper.assertEqual(expectedResult.rateAfterNetworkFee, zeroBN, "expected rate with network fee != actual rate for T2T");
+                Helper.assertEqual(expectedResult.rateAfterNetworkFee, actualResult.expectedRate, "expected rate with network fee != actual rate for T2T");
             });
 
             for (platformFee of platformFeeArray) {


### PR DESCRIPTION
Because of the stack too deep issue, I cannot instantiate another variable inside `getExpectedRateWithHintAndFee` to modify srcQty.

I thought I could do the fix in the local `calcRatesAndAmounts` function, but both `getExpectedRate` functions need the modified srcQty when calculating rates, so that doesn't work either.

I definitely cannot modify in the `initTradeInput`, because that's being used by the tradeWithHint functions, and the verification of `srcQty != 0` is done after this function.

Only workaround I'm left with, is to change `getExpectedRateWithHintAndFee` to public, so that I can modify srcQty directly.