### PR TITLE
 move gas helper call to end of trade flow

### DIFF
--- a/contractsSol5/KyberNetwork.sol
+++ b/contractsSol5/KyberNetwork.sol
@@ -907,22 +907,6 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils4, IKyberNetwork, Reentra
         require(rateAfterNetworkFee < MAX_RATE, "rate > MAX_RATE");
         require(rateAfterNetworkFee >= tData.input.minConversionRate, "rate < min Rate");
 
-        if (gasHelper != IGasHelper(0)) {
-            (bool success, ) = address(gasHelper).call(
-                abi.encodeWithSignature(
-                    "freeGas(address,address,address,uint256,bytes32[],bytes32[])",
-                    tData.input.platformWallet,
-                    tData.input.src,
-                    tData.input.dest,
-                    tData.tradeWei,
-                    tData.tokenToEth.ids,
-                    tData.ethToToken.ids
-                )
-            );
-            // remove compilation warning
-            success;
-        }
-
         uint actualSrcAmount;
 
         if (destAmount > tData.input.maxDestAmount) {
@@ -969,6 +953,22 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils4, IKyberNetwork, Reentra
             e2tIds: tData.ethToToken.ids,
             hint: hint
         });
+
+        if (gasHelper != IGasHelper(0)) {
+            (bool success, ) = address(gasHelper).call(
+                abi.encodeWithSignature(
+                    "freeGas(address,address,address,uint256,bytes32[],bytes32[])",
+                    tData.input.platformWallet,
+                    tData.input.src,
+                    tData.input.dest,
+                    tData.tradeWei,
+                    tData.tokenToEth.ids,
+                    tData.ethToToken.ids
+                )
+            );
+            // remove compilation warning
+            success;
+        }
 
         return (destAmount);
     }


### PR DESCRIPTION
gas helper call at end of flow has 2 advantages.

1. amounts are updated (after max dest amount calc).
2. burning gas tokens cost gas . the gas payback is only after all Tx is done. if not enough gas left to burn tokens, we should avoid burn since it can cause revert.