### PR TITLE
Simplify withdrawal logics to allow staker withdraw

### DIFF
--- a/contractsSol5/Dao/KyberDAO.sol
+++ b/contractsSol5/Dao/KyberDAO.sol
@@ -184,15 +184,15 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, CampPermissionGroup
     * @param staker address of staker to reduce reward
     * @param reduceAmount amount voting power to be reduced for each campaign staker has voted at this epoch
     */
-    function handleWithdrawal(address staker, uint reduceAmount) external onlyStakingContract returns(bool) {
+    function handleWithdrawal(address staker, uint reduceAmount) external onlyStakingContract {
         // staking shouldn't call this func with reduce amount = 0
-        if (reduceAmount == 0) { return false; }
+        if (reduceAmount == 0) { return; }
         uint curEpoch = getCurrentEpochNumber();
 
         // update total points for epoch
         uint numVotes = numberVotes[staker][curEpoch];
         // if no votes, no need to deduce points, but it should still return true to allow withdraw
-        if (numVotes == 0) { return true; }
+        if (numVotes == 0) { return; }
 
         totalEpochPoints[curEpoch] = totalEpochPoints[curEpoch].sub(numVotes.mul(reduceAmount));
 
@@ -213,8 +213,6 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, CampPermissionGroup
                 campaign.campaignVoteData.votePerOption[votedOption - 1] = campaign.campaignVoteData.votePerOption[votedOption - 1].sub(reduceAmount);
             }
         }
-
-        return true;
     }
 
     event NewCampaignCreated(

--- a/contractsSol5/Dao/KyberDAO.sol
+++ b/contractsSol5/Dao/KyberDAO.sol
@@ -421,7 +421,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, CampPermissionGroup
         public
         returns(uint burnInBps, uint rewardInBps, uint rebateInBps, uint epoch, uint expiryTimestamp)
     {
-        (burnInBps, rewardInBps, rebateInBps, epoch, expiryTimestamp) = getLatestBRRDataDecoded();
+        (burnInBps, rewardInBps, rebateInBps, epoch, expiryTimestamp) = getLatestBRRData();
         latestBrrData.rewardInBps = rewardInBps;
         latestBrrData.rebateInBps = rebateInBps;
     }
@@ -586,9 +586,9 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, CampPermissionGroup
     }
 
     /** 
-    * @dev return latest brr data after decoded so it is easily to check from read contract
+    * @dev return latest brr result, conclude brr campaign if needed
     */
-    function getLatestBRRDataDecoded()
+    function getLatestBRRData()
         public view
         returns(uint burnInBps, uint rewardInBps, uint rebateInBps, uint epoch, uint expiryTimestamp)
     {

--- a/contractsSol5/Dao/KyberStaking.sol
+++ b/contractsSol5/Dao/KyberStaking.sol
@@ -155,7 +155,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     event Withdraw(uint curEpoch, address staker, uint amount);
     // event is fired if something is wrong with withdrawal
     // even though the withdrawal is still success
-    event WithdrawFailure(uint curEpoch, address staker, uint amount);
+    event WithdrawDataUpdateFailed(uint curEpoch, address staker, uint amount);
 
     /**
     * @dev call to withdraw KNC from staking, it could affect reward when calling DAO handleWithdrawal
@@ -172,7 +172,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         (bool success,) = address(this).call(abi.encodeWithSignature("handleWithdrawal(address,uint256,uint256)",staker,amount,curEpoch));
         if (!success) {
             // Note: should catch this event to check if something went wrong
-            emit WithdrawFailure(curEpoch, staker, amount);
+            emit WithdrawDataUpdateFailed(curEpoch, staker, amount);
         }
 
         stakerLatestData[staker].stake = stakerLatestData[staker].stake.sub(amount);
@@ -336,7 +336,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
                 // don't revert if DAO revert so data will be updated correctly
                 (bool success,) = address(daoContract).call(abi.encodeWithSignature("handleWithdrawal(address,uint256)",dAddr,reduceAmount));
                 if (!success) {
-                    emit WithdrawFailure(curEpoch, staker, amount);
+                    emit WithdrawDataUpdateFailed(curEpoch, staker, amount);
                 }
             }
         }

--- a/contractsSol5/Dao/KyberStaking.sol
+++ b/contractsSol5/Dao/KyberStaking.sol
@@ -154,7 +154,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
 
     event Withdraw(uint curEpoch, address staker, uint amount);
     // event is fired if something is wrong with withdrawal
-    // even though the withdrawal is still success
+    // even though the withdrawal is still successful
     event WithdrawDataUpdateFailed(uint curEpoch, address staker, uint amount);
 
     /**

--- a/contractsSol5/Dao/KyberStaking.sol
+++ b/contractsSol5/Dao/KyberStaking.sol
@@ -7,7 +7,6 @@ import "./IKyberStaking.sol";
 import "../IKyberDAO.sol";
 import "./EpochUtils.sol";
 
-
 /*
 * This contract is using SafeMath for uint, which is inherited from EpochUtils
 */
@@ -154,6 +153,9 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     event Withdraw(uint curEpoch, address staker, uint amount);
+    // event is fired if something is wrong with withdrawal
+    // even though the withdrawal is still success
+    event WithdrawFailure(uint curEpoch, address staker, uint amount);
 
     /**
     * @dev call to withdraw KNC from staking, it could affect reward when calling DAO handleWithdrawal
@@ -167,40 +169,14 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
 
         require(stakerLatestData[staker].stake >= amount, "withdraw: latest amount staked < withdrawal amount");
 
-        initDataIfNeeded(staker, curEpoch);
-        // by right at here stake[curEpoch + 1][staker] should be equal stakerLatestData[staker].stake
-        assert(stakerPerEpochData[curEpoch + 1][staker].stake >= amount);
+        (bool success,) = address(this).call(abi.encodeWithSignature("handleWithdrawal(address,uint256,uint256)",staker,amount,curEpoch));
+        if (!success) {
+            // Note: should catch this event to check if something went wrong
+            emit WithdrawFailure(curEpoch, staker, amount);
+        }
 
-        stakerPerEpochData[curEpoch + 1][staker].stake = stakerPerEpochData[curEpoch + 1][staker].stake.sub(amount);
         stakerLatestData[staker].stake = stakerLatestData[staker].stake.sub(amount);
 
-        address dAddr = stakerPerEpochData[curEpoch][staker].delegatedAddress;
-        uint curStake = stakerPerEpochData[curEpoch][staker].stake;
-        uint lStakeBal = stakerLatestData[staker].stake;
-        uint newStake = curStake.min(lStakeBal);
-        uint reduceAmount = curStake.sub(newStake); // newStake is always <= curStake
-
-        if (reduceAmount > 0) {
-            if (dAddr != staker) {
-                initDataIfNeeded(dAddr, curEpoch);
-                // S has delegated to dAddr, withdraw will affect his stakes + dAddr's delegated stakes
-                stakerPerEpochData[curEpoch][dAddr].delegatedStake = stakerPerEpochData[curEpoch][dAddr].delegatedStake.sub(reduceAmount);
-            }
-            stakerPerEpochData[curEpoch][staker].stake = newStake;
-            // call DAO to reduce reward, if staker has delegated, then pass his delegated address
-            if (address(daoContract) != address(0)) {
-                require(daoContract.handleWithdrawal(dAddr, reduceAmount), "withdraw: dao returns false for handle withdrawal");
-            }
-        }
-        dAddr = stakerPerEpochData[curEpoch + 1][staker].delegatedAddress;
-        if (dAddr != staker) {
-            initDataIfNeeded(dAddr, curEpoch);
-            // delegated stake shouldn't be greater than withdrawal amount at this point
-            assert(stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake >= amount);
-            assert(stakerLatestData[dAddr].delegatedStake >= amount);
-            stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake = stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.sub(amount);
-            stakerLatestData[dAddr].delegatedStake = stakerLatestData[dAddr].delegatedStake.sub(amount);
-        }
         // transfer KNC back to user
         require(kncToken.transfer(staker, amount), "withdraw: can not transfer knc to the sender");
         emit Withdraw(curEpoch, staker, amount);
@@ -333,6 +309,42 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
             nextEpochStakerData.delegatedAddress = ldAddress;
             nextEpochStakerData.delegatedStake = ldStake;
             nextEpochStakerData.stake = lStakeBal;
+        }
+    }
+
+    function handleWithdrawal(address staker, uint amount, uint curEpoch) public {
+        require(msg.sender == address(this), "only staking contract can call this function");
+        initDataIfNeeded(staker, curEpoch);
+        // update latest stake will be done after this function
+        stakerPerEpochData[curEpoch + 1][staker].stake = stakerPerEpochData[curEpoch + 1][staker].stake.sub(amount);
+
+        address dAddr = stakerPerEpochData[curEpoch][staker].delegatedAddress;
+        uint curStake = stakerPerEpochData[curEpoch][staker].stake;
+        uint lStakeBal = stakerLatestData[staker].stake.sub(amount);
+        uint newStake = curStake.min(lStakeBal);
+        uint reduceAmount = curStake.sub(newStake); // newStake is always <= curStake
+
+        if (reduceAmount > 0) {
+            if (dAddr != staker) {
+                initDataIfNeeded(dAddr, curEpoch);
+                // S has delegated to dAddr, withdraw will affect his stakes + dAddr's delegated stakes
+                stakerPerEpochData[curEpoch][dAddr].delegatedStake = stakerPerEpochData[curEpoch][dAddr].delegatedStake.sub(reduceAmount);
+            }
+            stakerPerEpochData[curEpoch][staker].stake = newStake;
+            // call DAO to reduce reward, if staker has delegated, then pass his delegated address
+            if (address(daoContract) != address(0)) {
+                // don't revert if DAO revert so data will be updated correctly
+                (bool success,) = address(daoContract).call(abi.encodeWithSignature("handleWithdrawal(address,uint256)",dAddr,reduceAmount));
+                if (!success) {
+                    emit WithdrawFailure(curEpoch, staker, amount);
+                }
+            }
+        }
+        dAddr = stakerPerEpochData[curEpoch + 1][staker].delegatedAddress;
+        if (dAddr != staker) {
+            initDataIfNeeded(dAddr, curEpoch);
+            stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake = stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.sub(amount);
+            stakerLatestData[dAddr].delegatedStake = stakerLatestData[dAddr].delegatedStake.sub(amount);
         }
     }
 }

--- a/contractsSol5/Dao/mock/MockKyberDAOTestHandleWithdrawal.sol
+++ b/contractsSol5/Dao/mock/MockKyberDAOTestHandleWithdrawal.sol
@@ -10,9 +10,8 @@ contract MockKyberDAOTestHandleWithdrawal is EpochUtils {
         firstEpochStartTimestamp = _startTimestamp;
     }
 
-    function handleWithdrawal(address staker, uint amount) public returns(bool) {
+    function handleWithdrawal(address staker, uint amount) public {
         // to test if staking has called this func or not when withdrawing
         values[staker] += amount;
-        return true;
     }
 }

--- a/contractsSol5/Dao/mock/MockKyberDaoWithdrawFailed.sol
+++ b/contractsSol5/Dao/mock/MockKyberDaoWithdrawFailed.sol
@@ -11,8 +11,8 @@ contract MockKyberDaoWithdrawFailed is EpochUtils {
         firstEpochStartTimestamp = _startTimestamp;
     }
 
-    function handleWithdrawal(address, uint) public returns(bool) {
+    function handleWithdrawal(address, uint) public {
         value++;
-        return false;
+        revert();
     }
 }

--- a/contractsSol5/Dao/mock/MockKyberStakingMalicious.sol
+++ b/contractsSol5/Dao/mock/MockKyberStakingMalicious.sol
@@ -7,6 +7,10 @@ contract MockKyberStakingMalicious is KyberStaking {
     constructor(address _kncToken, uint _epochPeriod, uint _startBlock, address _admin) 
         KyberStaking(_kncToken, _epochPeriod, _startBlock, _admin) public { }
 
+    function getHasInitedValue(address staker, uint epoch) public view returns(bool) {
+        return hasInited[epoch][staker];
+    }
+
     function setLatestStake(address staker, uint amount) public {
         stakerLatestData[staker].stake = amount;
     }

--- a/contractsSol5/Dao/mock/MockMaliciousDaoReentrancy.sol
+++ b/contractsSol5/Dao/mock/MockMaliciousDaoReentrancy.sol
@@ -29,13 +29,12 @@ contract MockMaliciousDaoReentrancy is EpochUtils {
         staking.withdraw(amount);
     }
 
-    function handleWithdrawal(address, uint) public returns(bool) {
+    function handleWithdrawal(address, uint) public {
         if (totalDeposit > 0) {
             // reentrant one
             uint amount = totalDeposit;
             totalDeposit = 0;
             staking.withdraw(amount);
         }
-        return true;
     }
 }

--- a/contractsSol5/IKyberDAO.sol
+++ b/contractsSol5/IKyberDAO.sol
@@ -7,7 +7,7 @@ interface IKyberDAO {
 
     function vote(uint campaignID, uint option) external;
 
-    function handleWithdrawal(address staker, uint penaltyAmount) external returns(bool);
+    function handleWithdrawal(address staker, uint penaltyAmount) external;
     function shouldBurnRewardForEpoch(uint epoch) external view returns(bool);
     function getLatestNetworkFeeData() external view returns(uint feeInBps, uint expiryTimestamp);
     function getLatestNetworkFeeDataWithCache() external returns(uint feeInBps, uint expiryTimestamp);

--- a/contractsSol5/mock/MockDAO.sol
+++ b/contractsSol5/mock/MockDAO.sol
@@ -103,11 +103,9 @@ contract MockDAO is IKyberDAO, Utils4 {
 
     function handleWithdrawal(address staker, uint256 reduceAmount)
         external
-        returns (bool)
     {
         staker;
         reduceAmount;
-        return true;
     }
 
     function shouldBurnRewardForEpoch(uint256 epochNum)

--- a/test/sol5/kyberDao.js
+++ b/test/sol5/kyberDao.js
@@ -5182,7 +5182,7 @@ contract('KyberDAO', function(accounts) {
       await deployContracts(10, currentBlock + 10, 5);
 
       Helper.assertEqual(defaultBrrData, await daoContract.latestBrrResult(), "brr default is wrong");
-      let dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      let dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn default is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward default is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate default is wrong");
@@ -5207,7 +5207,7 @@ contract('KyberDAO', function(accounts) {
       await daoContract.checkLatestBrrData(
         reward, rebate, 10000 - rebate - reward, 0, daoStartTime - 1
       );
-      dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn default is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward default is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate default is wrong");
@@ -5228,7 +5228,7 @@ contract('KyberDAO', function(accounts) {
       await daoContract.checkLatestBrrData(
         reward, rebate, 10000 - rebate - reward, 1, blocksToSeconds(epochPeriod) + daoStartTime - 1
       );
-      let dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      let dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn default is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward default is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate default is wrong");
@@ -5250,7 +5250,7 @@ contract('KyberDAO', function(accounts) {
         reward, rebate, 10000 - rebate - reward, 4, blocksToSeconds(epochPeriod * 4) + daoStartTime - 1
       );
 
-      dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate is wrong");
@@ -5333,7 +5333,7 @@ contract('KyberDAO', function(accounts) {
         reward, rebate, 10000 - rebate - reward, 1, blocksToSeconds(epochPeriod) + daoStartTime - 1
       );
       Helper.assertEqual(1, await daoContract.brrCampaigns(1), "should have brr camp");
-      let dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      let dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate is wrong");
@@ -5343,7 +5343,7 @@ contract('KyberDAO', function(accounts) {
       // delay to epoch 2, winning option should take effect
       await Helper.mineNewBlockAt(blocksToSeconds(epochPeriod) + daoStartTime);
 
-      dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - newRebate - newReward, dataDecoded.burnInBps, "burn is wrong");
       Helper.assertEqual(newReward, dataDecoded.rewardInBps, "reward is wrong");
       Helper.assertEqual(newRebate, dataDecoded.rebateInBps, "rebate is wrong");
@@ -5356,7 +5356,7 @@ contract('KyberDAO', function(accounts) {
       Helper.assertEqual(brrData, await daoContract.latestBrrResult(), "latest brr is wrong");
 
       // test winning option is encoded
-      dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - newRebate - newReward, dataDecoded.burnInBps, "burn is wrong");
       Helper.assertEqual(newReward, dataDecoded.rewardInBps, "reward is wrong");
       Helper.assertEqual(newRebate, dataDecoded.rebateInBps, "rebate is wrong");
@@ -5398,7 +5398,7 @@ contract('KyberDAO', function(accounts) {
       await daoContract.checkLatestBrrData(
         reward, rebate, 10000 - rebate - reward, 2, blocksToSeconds(epochPeriod * 2) + daoStartTime - 1
       );
-      let dataDecoded = await daoContract.getLatestBRRDataDecoded();
+      let dataDecoded = await daoContract.getLatestBRRData();
       Helper.assertEqual(10000 - rebate - reward, dataDecoded.burnInBps, "burn is wrong");
       Helper.assertEqual(reward, dataDecoded.rewardInBps, "reward is wrong");
       Helper.assertEqual(rebate, dataDecoded.rebateInBps, "rebate is wrong");

--- a/test/sol5/kyberIntegration.js
+++ b/test/sol5/kyberIntegration.js
@@ -239,7 +239,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         Helper.assertEqual(expectedReward, brrData.rewardBps);
         Helper.assertEqual(expectedRebate, brrData.rebateBps);
         // check expected brr data from dao
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(brrData.expiryTimestamp, daoBrrData.expiryTimestamp);
         Helper.assertEqual(brrData.epoch, daoBrrData.epoch);
         Helper.assertEqual(brrData.rewardBps, daoBrrData.rewardInBps);
@@ -304,7 +304,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         Helper.assertLesser(brrData.expiryTimestamp, daoStartTime - 1);
         Helper.assertEqual(brrData.epoch, 0);
 
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         let daoNetworkFee = (await daoContract.getLatestNetworkFeeData()).feeInBps;
 
         // make a first trade and check data changes as expected
@@ -331,7 +331,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
 
         // no campaign yet, so still default data from DAO
 
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         let daoNetworkFee = (await daoContract.getLatestNetworkFeeData()).feeInBps;
 
         await tradeAndCheckDataChangesAsExpected(
@@ -382,7 +382,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated without winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, curNetworkFee);
         // brr camp should be updated without winning option
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(2 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(2, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps, daoBrrData.rewardInBps);
@@ -444,7 +444,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated without winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, curNetworkFee);
         // brr camp should be updated with no winning option
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(3 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(3, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps, daoBrrData.rewardInBps);
@@ -506,7 +506,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated without winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, curNetworkFee);
         // brr camp should be updated with option 1 winning
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(4 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(4, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps.add(new BN(1)), daoBrrData.rewardInBps);
@@ -609,7 +609,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated with winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, newFee1);
         // brr camp should be updated without winning option
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(6 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(6, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps, daoBrrData.rewardInBps);
@@ -671,7 +671,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated with winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, newFee1);
         // brr camp should be updated with winning option
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(7 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(7, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps.add(new BN(1)), daoBrrData.rewardInBps);
@@ -738,7 +738,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         Helper.assertEqual(curBrrData.rewardBps, brrData.rewardBps);
         Helper.assertEqual(curBrrData.rebateBps, brrData.rebateBps);
         // check expected brr data from dao
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(11 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(11, daoBrrData.epoch);
         Helper.assertEqual(brrData.rewardBps, daoBrrData.rewardInBps);
@@ -958,7 +958,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         // network fee camp should be updated without winning option
         Helper.assertEqual((await daoContract.getLatestNetworkFeeData()).feeInBps, curNetworkFee);
         // brr camp should be updated without winning option
-        let daoBrrData = await daoContract.getLatestBRRDataDecoded();
+        let daoBrrData = await daoContract.getLatestBRRData();
         Helper.assertEqual(blocksToSeconds(18 * epochPeriod) + daoStartTime - 1, daoBrrData.expiryTimestamp);
         Helper.assertEqual(18, daoBrrData.epoch);
         Helper.assertEqual(curBrrData.rewardBps, daoBrrData.rewardInBps);


### PR DESCRIPTION
Current with withdraw function has complex logics updating data in Staking and Dao contract
We want to allow staker withdraws their stake even if something is wrong with DAO or updating data in Staking, only need to check if staker's latest stake >= withdrawal amount