### PR TITLE
small improvement for split trades. when calculating destAmount 

### DIFF
--- a/contractsSol5/KyberNetwork.sol
+++ b/contractsSol5/KyberNetwork.sol
@@ -862,6 +862,12 @@ contract KyberNetwork is
         TradeData memory tData
     ) internal pure returns (uint256 destAmount) {
         uint256 totalBps;
+        uint256 srcDecimals = (src == ETH_TOKEN_ADDRESS)
+            ? ETH_DECIMALS
+            : tradingReserves.decimals;
+        uint256 destDecimals = (src == ETH_TOKEN_ADDRESS)
+            ? tradingReserves.decimals
+            : ETH_DECIMALS;
 
         for (uint256 i = 0; i < tradingReserves.addresses.length; i++) {
             if (
@@ -874,12 +880,8 @@ contract KyberNetwork is
 
             destAmount += calcDstQty(
                 tradingReserves.srcAmounts[i],
-                (src == ETH_TOKEN_ADDRESS)
-                    ? ETH_DECIMALS
-                    : tradingReserves.decimals,
-                (src == ETH_TOKEN_ADDRESS)
-                    ? tradingReserves.decimals
-                    : ETH_DECIMALS,
+                srcDecimals,
+                destDecimals,
                 tradingReserves.rates[i]
             );
 


### PR DESCRIPTION
bytecode size diff
after this change: 23376
before this change: 23369

gas
for split before:
2e: 541075 gas used, type: SPLIT fee: 123 num reserves: 3
e2t: 531420 gas used, type: SPLIT fee: 123 num reserves: 3
t2t: 921553 gas used, type: SPLIT fee: 123 num reserves: 3

after: 
t2e: 540689 gas used, type: SPLIT fee: 123 num reserves: 3
e2t: 531074 gas used, type: SPLIT fee: 123 num reserves: 3
t2t: 920821 gas used, type: SPLIT fee: 123 num reserves: 3

non split before:
t2e: 478351 gas used, type: NO HINT fee: 123 num reserves: 3
e2t: 519036 gas used, type: NO HINT fee: 123 num reserves: 3
t2t: 878734 gas used, type: NO HINT fee: 123 num reserves: 3

after:
t2e: 478359 gas used, type: NO HINT fee: 123 num reserves: 3
e2t: 519044 gas used, type: NO HINT fee: 123 num reserves: 3
t2t: 878750 gas used, type: NO HINT fee: 123 num reserves: 3