### PR TITLE
enable setting DAO Address to 0.

### DIFF
--- a/contracts/sol6/KyberNetwork.sol
+++ b/contracts/sol6/KyberNetwork.sol
@@ -317,13 +317,13 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
     }
 
     function setDAOContract(IKyberDAO _kyberDAO) external {
+        // enable setting 0 address DAO.
         onlyAdmin();
         if (kyberDAO != _kyberDAO) {
             kyberDAO = _kyberDAO;
             require(kyberStorage.setDAOContract(_kyberDAO));
             emit KyberDAOUpdated(_kyberDAO);
         }
-        require(_kyberDAO != IKyberDAO(0));
     }
 
     function setParams(uint256 _maxGasPrice, uint256 _negligibleRateDiffBps) external {

--- a/contracts/sol6/KyberStorage.sol
+++ b/contracts/sol6/KyberStorage.sol
@@ -74,7 +74,7 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers {
 
     function setDAOContract(IKyberDAO _kyberDAO) external override returns (bool) {
         onlyNetwork();
-        require(_kyberDAO != IKyberDAO(0), "kyberDAO 0");
+        
         if (kyberDAO.length > 0) {
             kyberDAO.push(kyberDAO[0]);
             kyberDAO[0] = _kyberDAO;

--- a/test/sol6/kyberNetwork.js
+++ b/test/sol6/kyberNetwork.js
@@ -355,11 +355,11 @@ contract('KyberNetwork', function(accounts) {
             );
         });
 
-        it("set empty dao contract", async function(){
-            await expectRevert(
-                tempNetwork.setDAOContract(zeroAddress, {from: admin}),
-                "kyberDAO 0"
-            );
+        it("should enable setting an empty dao contract", async function(){
+            await tempNetwork.setDAOContract(zeroAddress, {from: admin});
+            
+            let rxContracts = await tempNetwork.getContracts();
+            assert.equal(rxContracts.daoAddress, zeroAddress);
         });
     });
 

--- a/test/sol6/kyberStorage.js
+++ b/test/sol6/kyberStorage.js
@@ -308,13 +308,6 @@ contract('KyberStorage', function(accounts) {
             );
         });
 
-        it("set empty dao contract", async function(){
-            await expectRevert(
-                kyberStorage.setDAOContract(zeroAddress, {from: network}),
-                "kyberDAO 0"
-            );
-        });
-
         it("set and get contracts history", async() =>{
             await kyberStorage.setDAOContract(DAOAddr, { from: network});
             await kyberStorage.setContracts(feeHandlerAddr, matchingEngineAddr, { from: network });
@@ -331,6 +324,14 @@ contract('KyberStorage', function(accounts) {
             Helper.assertEqualArray(result.daoAddresses, [DAOAddr2, DAOAddr], "unexpected dao history");
             Helper.assertEqualArray(result.matchingEngineAddresses, [matchingEngineAddr2, matchingEngineAddr], "unexpected match engine history");
             Helper.assertEqualArray(result.feeHandlerAddresses, [feeHandlerAddr2, feeHandlerAddr], "unexpected fee handler history");
+        });
+
+        it("should enable setting an empty dao contract", async function(){
+            await kyberStorage.setDAOContract(zeroAddress, {from: network});
+
+            let rxContracts = await kyberStorage.getContracts();
+
+            assert.equal(rxContracts.daoAddresses[0], zeroAddress);
         });
     });
 


### PR DESCRIPTION
the network should be able to work without any DAO connected.

so in the case of an issue with the DAO contract. we would like to enable setting DAO Address to 0