### PR TITLE
[Don't merge] Add DaoOperator for FeeHandler + KyberDAO, allow updating proxy in FeeHandler

### DIFF
--- a/contracts/sol6/Dao/DaoOperator.sol
+++ b/contracts/sol6/Dao/DaoOperator.sol
@@ -1,0 +1,16 @@
+pragma solidity 0.6.6;
+
+
+contract DaoOperator {
+    address public daoOperator;
+
+    constructor(address _daoOperator) public {
+        require(_daoOperator != address(0), "daoOperator is 0");
+        daoOperator = _daoOperator;
+    }
+
+    modifier onlyDaoOperator() {
+        require(msg.sender == daoOperator, "only daoOperator");
+        _;
+    }
+}

--- a/contracts/sol6/Dao/IKyberStaking.sol
+++ b/contracts/sol6/Dao/IKyberStaking.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.6.6;
 
 import "./IEpochUtils.sol";
+import "../IERC20.sol";
 
 
 interface IKyberStaking is IEpochUtils {
@@ -35,4 +36,6 @@ interface IKyberStaking is IEpochUtils {
             uint256 _delegatedStake,
             address _delegatedAddress
         );
+
+    function kncToken() external view returns (IERC20);
 }

--- a/contracts/sol6/Dao/KyberDAO.sol
+++ b/contracts/sol6/Dao/KyberDAO.sol
@@ -2,7 +2,6 @@ pragma solidity 0.6.6;
 
 import "./EpochUtils.sol";
 import "./DaoOperator.sol";
-import "../IERC20.sol";
 import "./IKyberStaking.sol";
 import "../IKyberDAO.sol";
 import "../utils/zeppelin/ReentrancyGuard.sol";
@@ -57,7 +56,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
 
     // minimum duration in seconds for a campaign
     uint256 public minCampaignDurationInSeconds = 345600; // around 4 days
-    IERC20 public kncToken;
+    IERC20 public override kncToken;
     IKyberStaking public staking;
     IKyberFeeHandler public feeHandler;
 
@@ -128,6 +127,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
             staking.firstEpochStartTimestamp() == _startTimestamp,
             "ctor: diff start timestamp"
         );
+        require(staking.kncToken() == IERC20(_knc), "ctor: diff knc token");
 
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;

--- a/contracts/sol6/Dao/KyberDAO.sol
+++ b/contracts/sol6/Dao/KyberDAO.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.6.6;
 
 import "./EpochUtils.sol";
+import "./DaoOperator.sol";
 import "../IERC20.sol";
 import "./IKyberStaking.sol";
 import "../IKyberDAO.sol";
@@ -16,7 +17,7 @@ import "../IKyberFeeHandler.sol";
  *      BRR fee handler campaign: options are combined of rebate (left most 128 bits) + reward (right most 128 bits)
  *      General campaign: options are from 1 to num_options
  */
-contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
+contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator {
     /* Constants */
     // max number of campaigns for each epoch
     uint256 public   constant MAX_EPOCH_CAMPAIGNS = 10;
@@ -60,10 +61,6 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
     IKyberStaking public staking;
     IKyberFeeHandler public feeHandler;
 
-    // campaign creator permissions
-    address public campaignCreator;
-    address public pendingCampaignCreator;
-
     /* Mapping from campaign ID => data */
     // use to generate increasing campaign ID
     uint256 public numberCampaigns = 0;
@@ -90,9 +87,6 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
     // epoch => campaignID for brr campaigns
     mapping(uint256 => uint256) public brrCampaigns;
 
-    event TransferCampaignCreatorPending(address pendingCampaignCreator);
-    event CampaignCreatorClaimed(address newCampaignCreator, address previousCampaignCreator);
-
     event NewCampaignCreated(
         CampaignType campaignType,
         uint256 indexed campaignID,
@@ -116,14 +110,13 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
         uint256 _defaultNetworkFeeBps,
         uint256 _defaultRewardBps,
         uint256 _defaultRebateBps,
-        address _campaignCreator
-    ) public {
+        address _daoOperator
+    ) public DaoOperator(_daoOperator) {
         require(_epochPeriod > 0, "ctor: epoch period is 0");
         require(_startTimestamp >= now, "ctor: start in the past");
         require(_staking != address(0), "ctor: staking is missing");
         require(_feeHandler != address(0), "ctor: feeHandler is missing");
         require(_knc != address(0), "ctor: knc token is missing");
-        require(_campaignCreator != address(0), "campaignCreator is 0");
         // in Network, maximum fee that can be taken from 1 tx is (platform fee + 2 * network fee)
         // so network fee should be less than 50%
         require(_defaultNetworkFeeBps < BPS / 2, "ctor: network fee high");
@@ -146,52 +139,11 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
             rewardInBps: _defaultRewardBps,
             rebateInBps: _defaultRebateBps
         });
-        campaignCreator = _campaignCreator;
-    }
-
-    modifier onlyCampaignCreator() {
-        require(msg.sender == campaignCreator, "only campaign creator");
-        _;
     }
 
     modifier onlyStakingContract {
         require(msg.sender == address(staking), "only staking contract");
         _;
-    }
-
-    /**
-     * @dev Allows the current campaignCreator to set the pendingCampaignCreator address.
-     * @param newCampaignCreator The address to transfer ownership to.
-     */
-    function transferCampaignCreator(address newCampaignCreator) external onlyCampaignCreator {
-        require(newCampaignCreator != address(0), "newCampaignCreator is 0");
-        emit TransferCampaignCreatorPending(newCampaignCreator);
-        pendingCampaignCreator = newCampaignCreator;
-    }
-
-    /**
-     * @dev Allows the current campCcampaignCreatorreator to set the campaignCreator in one tx.
-            Useful initial deployment.
-     * @param newCampaignCreator The address to transfer ownership to.
-     */
-    function transferCampaignCreatorQuickly(address newCampaignCreator)
-        external
-        onlyCampaignCreator
-    {
-        require(newCampaignCreator != address(0), "newCampaignCreator is 0");
-        emit TransferCampaignCreatorPending(newCampaignCreator);
-        emit CampaignCreatorClaimed(newCampaignCreator, campaignCreator);
-        campaignCreator = newCampaignCreator;
-    }
-
-    /**
-     * @dev Allows the pendingCampaignCreator address to finalize the change campaign creator process.
-     */
-    function claimCampaignCreator() external {
-        require(pendingCampaignCreator == msg.sender, "only pending campaign creator");
-        emit CampaignCreatorClaimed(pendingCampaignCreator, campaignCreator);
-        campaignCreator = pendingCampaignCreator;
-        pendingCampaignCreator = address(0);
     }
 
     /**
@@ -239,7 +191,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
     }
 
     /**
-     * @dev create new campaign, only called by campaignCreator
+     * @dev create new campaign, only called by daoOperator
      * @param campaignType type of campaign (General, NetworkFee, FeeHandlerBRR)
      * @param startTimestamp timestamp to start running the campaign
      * @param endTimestamp timestamp to end this campaign
@@ -258,7 +210,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
         uint256 tInPrecision,
         uint256[] calldata options,
         bytes calldata link
-    ) external onlyCampaignCreator returns (uint256 campaignID) {
+    ) external onlyDaoOperator returns (uint256 campaignID) {
         // campaign epoch could be different from current epoch
         // as we allow to create campaign of next epoch as well
         uint256 campaignEpoch = getEpochNumber(startTimestamp);
@@ -342,11 +294,11 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5 {
     }
 
     /**
-     * @dev  cancel a campaign with given id, called by campaignCreator only
+     * @dev  cancel a campaign with given id, called by daoOperator only
      *       only can cancel campaigns that have not started yet
      * @param campaignID id of the campaign to cancel
      */
-    function cancelCampaign(uint256 campaignID) external onlyCampaignCreator {
+    function cancelCampaign(uint256 campaignID) external onlyDaoOperator {
         Campaign storage campaign = campaignData[campaignID];
         require(campaign.campaignExists, "cancelCampaign: campaignID doesn't exist");
 

--- a/contracts/sol6/Dao/KyberDAO.sol
+++ b/contracts/sol6/Dao/KyberDAO.sol
@@ -113,21 +113,21 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
     ) public DaoOperator(_daoOperator) {
         require(_epochPeriod > 0, "ctor: epoch period is 0");
         require(_startTimestamp >= now, "ctor: start in the past");
-        require(_staking != address(0), "ctor: staking is missing");
-        require(_feeHandler != address(0), "ctor: feeHandler is missing");
-        require(_knc != address(0), "ctor: knc token is missing");
+        require(_staking != address(0), "ctor: staking 0");
+        require(_feeHandler != address(0), "ctor: feeHandler 0");
+        require(_knc != address(0), "ctor: knc token 0");
         // in Network, maximum fee that can be taken from 1 tx is (platform fee + 2 * network fee)
         // so network fee should be less than 50%
         require(_defaultNetworkFeeBps < BPS / 2, "ctor: network fee high");
         require(_defaultRewardBps.add(_defaultRebateBps) <= BPS, "reward plus rebate high");
 
         staking = IKyberStaking(_staking);
-        require(staking.epochPeriodInSeconds() == _epochPeriod, "ctor: diff epoch period");
+        require(staking.epochPeriodInSeconds() == _epochPeriod, "ctor: different epoch period");
         require(
             staking.firstEpochStartTimestamp() == _startTimestamp,
-            "ctor: diff start timestamp"
+            "ctor: different start timestamp"
         );
-        require(staking.kncToken() == IERC20(_knc), "ctor: diff knc token");
+        require(staking.kncToken() == IERC20(_knc), "ctor: different knc token");
 
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;
@@ -385,7 +385,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
         require(!hasClaimedReward[staker][epoch], "claimReward: already claimed");
 
         uint256 perInPrecision = getStakerRewardPercentageInPrecision(staker, epoch);
-        require(perInPrecision > 0, "claimReward: No reward");
+        require(perInPrecision > 0, "claimReward: no reward");
 
         hasClaimedReward[staker][epoch] = true;
         // call fee handler to claim reward
@@ -722,7 +722,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
                 // so network fee should be less than 50%
                 require(
                     options[i] < BPS / 2,
-                    "validateParams: Fee campaign option value is too high"
+                    "validateParams: fee campaign option value is too high"
                 );
             }
         } else {

--- a/contracts/sol6/Dao/KyberFeeHandler.sol
+++ b/contracts/sol6/Dao/KyberFeeHandler.sol
@@ -99,7 +99,7 @@ contract KyberFeeHandler is IKyberFeeHandler, DaoOperator, Utils5 {
     event BurnConfigSet(ISanityRate sanityRate, uint256 weiToBurn);
     event RewardsRemovedToBurn(uint256 indexed epoch, uint256 rewardsWei);
     event KyberNetworkUpdated(address kyberNetwork);
-    event KyberProxyUpdated(IKyberProxy indexed newProxy, IKyberProxy indexed oldProxy);
+    event KyberProxyUpdated(IKyberProxy kyberProxy);
 
     constructor(
         address _daoSetter,
@@ -292,6 +292,15 @@ contract KyberFeeHandler is IKyberFeeHandler, DaoOperator, Utils5 {
         daoSetter = address(0);
     }
 
+    /// @dev set new kyber network address
+    function setNetworkContract(address _kyberNetwork) external onlyDaoOperator {
+        require(_kyberNetwork != address(0), "KyberNetwork 0");
+        if (_kyberNetwork != kyberNetwork) {
+            kyberNetwork = _kyberNetwork;
+            emit KyberNetworkUpdated(kyberNetwork);
+        }
+    }
+
     /// @dev set burn KNC sanity rate contract and amount wei to burn
     /// @param _sanityRate new sanity rate contract
     /// @param _weiToBurn new amount of wei to burn
@@ -321,10 +330,8 @@ contract KyberFeeHandler is IKyberFeeHandler, DaoOperator, Utils5 {
     function setNetworkProxy(IKyberProxy _newProxy) external onlyDaoOperator {
         require(_newProxy != IKyberProxy(0), "new proxy is 0");
         if (_newProxy != networkProxy) {
-            emit KyberProxyUpdated(_newProxy, networkProxy);
             networkProxy = _newProxy;
-            // update network contract
-            updateNetworkContract();
+            emit KyberProxyUpdated(_newProxy);
         }
     }
 
@@ -400,14 +407,6 @@ contract KyberFeeHandler is IKyberFeeHandler, DaoOperator, Utils5 {
         if (sanityRateContract.length > 0 && sanityRateContract[0] != ISanityRate(0)) {
             kncToEthSanityRate = sanityRateContract[0].latestAnswer();
         }
-    }
-
-    /// @dev update kyber network contract address via kyber proxy.
-    function updateNetworkContract() public onlyDaoOperator {
-        address _kyberNetwork = networkProxy.kyberNetwork();
-        require(_kyberNetwork != address(0), "KyberNetwork 0");
-        kyberNetwork = _kyberNetwork;
-        emit KyberNetworkUpdated(kyberNetwork);
     }
 
     function getBRR()

--- a/contracts/sol6/Dao/KyberStaking.sol
+++ b/contracts/sol6/Dao/KyberStaking.sol
@@ -40,10 +40,10 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         uint256 _startTimestamp,
         address _daoContractSetter
     ) public {
-        require(_epochPeriod > 0, "ctor: epoch duration must be positive");
-        require(_startTimestamp >= now, "ctor: start timestamp should not be in the past");
-        require(_kncToken != address(0), "ctor: KNC address is missing");
-        require(_daoContractSetter != address(0), "ctor: daoContractSetter address is missing");
+        require(_epochPeriod > 0, "ctor: epoch period is 0");
+        require(_startTimestamp >= now, "ctor: start in the past");
+        require(_kncToken != address(0), "ctor: kncToken 0");
+        require(_daoContractSetter != address(0), "ctor: daoContractSetter 0");
 
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;
@@ -52,7 +52,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     modifier onlyDAOContractSetter() {
-        require(msg.sender == daoContractSetter, "sender is not daoContractSetter");
+        require(msg.sender == daoContractSetter, "only daoContractSetter");
         _;
     }
 
@@ -61,21 +61,21 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
      * @param _daoAddress address of new DAO
      */
     function updateDAOAddressAndRemoveSetter(address _daoAddress) external onlyDAOContractSetter {
-        require(_daoAddress != address(0), "updateDAO: DAO address is missing");
+        require(_daoAddress != address(0), "updateDAO: daoAddress 0");
 
         daoContract = IKyberDAO(_daoAddress);
         // verify the same epoch period + start timestamp
         require(
             daoContract.epochPeriodInSeconds() == epochPeriodInSeconds,
-            "updateDAO: DAO and Staking have different epoch period"
+            "updateDAO: different epoch period"
         );
         require(
             daoContract.firstEpochStartTimestamp() == firstEpochStartTimestamp,
-            "updateDAO: DAO and Staking have different start timestamp"
+            "updateDAO: different start timestamp"
         );
         require(
             daoContract.kncToken() == kncToken,
-            "updateDAO: DAO and Staking have different knc token"
+            "updateDAO: different knc token"
         );
 
         emit DAOAddressSet(_daoAddress);
@@ -91,7 +91,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
      * @param dAddr address to delegate to
      */
     function delegate(address dAddr) external override {
-        require(dAddr != address(0), "delegate: delegated address should not be 0x0");
+        require(dAddr != address(0), "delegate: delegated address 0");
         address staker = msg.sender;
         uint256 curEpoch = getCurrentEpochNumber();
 
@@ -223,7 +223,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     {
         require(
             msg.sender == address(daoContract),
-            "initAndReturnData: sender is not DAO address"
+            "initAndReturnData: only daoContract"
         );
 
         uint256 curEpoch = getCurrentEpochNumber();
@@ -351,7 +351,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         uint256 amount,
         uint256 curEpoch
     ) public {
-        require(msg.sender == address(this), "only staking contract can call this function");
+        require(msg.sender == address(this), "only staking contract");
         initDataIfNeeded(staker, curEpoch);
         // Note: update latest stake will be done after this function
         // update staker's data for next epoch

--- a/contracts/sol6/Dao/KyberStaking.sol
+++ b/contracts/sol6/Dao/KyberStaking.sol
@@ -1,6 +1,5 @@
 pragma solidity 0.6.6;
 
-import "../IERC20.sol";
 import "../utils/zeppelin/ReentrancyGuard.sol";
 import "./IKyberStaking.sol";
 import "../IKyberDAO.sol";
@@ -18,7 +17,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         address delegatedAddress;
     }
 
-    IERC20 public kncToken;
+    IERC20 public override kncToken;
     IKyberDAO public daoContract;
     address public daoContractSetter;
 
@@ -73,6 +72,10 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         require(
             daoContract.firstEpochStartTimestamp() == firstEpochStartTimestamp,
             "updateDAO: DAO and Staking have different start timestamp"
+        );
+        require(
+            daoContract.kncToken() == kncToken,
+            "updateDAO: DAO and Staking have different knc token"
         );
 
         emit DAOAddressSet(_daoAddress);

--- a/contracts/sol6/Dao/mock/MockKyberDAOTestHandleWithdrawal.sol
+++ b/contracts/sol6/Dao/mock/MockKyberDAOTestHandleWithdrawal.sol
@@ -1,14 +1,17 @@
 pragma solidity 0.6.6;
 
 import "../EpochUtils.sol";
+import "../../IERC20.sol";
 
 
 contract MockKyberDAOTestHandleWithdrawal is EpochUtils {
+    IERC20 public kncToken;
     mapping(address => uint256) public values;
 
-    constructor(uint256 _epochPeriod, uint256 _startTimestamp) public {
+    constructor(uint256 _epochPeriod, uint256 _startTimestamp, address _kncToken) public {
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;
+        kncToken = IERC20(_kncToken);
     }
 
     function handleWithdrawal(address staker, uint256 amount) public {

--- a/contracts/sol6/Dao/mock/MockKyberDaoWithdrawFailed.sol
+++ b/contracts/sol6/Dao/mock/MockKyberDaoWithdrawFailed.sol
@@ -1,14 +1,17 @@
 pragma solidity 0.6.6;
 
 import "../EpochUtils.sol";
+import "../../IERC20.sol";
 
 
 contract MockKyberDaoWithdrawFailed is EpochUtils {
+    IERC20 public kncToken;
     uint256 public value;
 
-    constructor(uint256 _epochPeriod, uint256 _startTimestamp) public {
+    constructor(uint256 _epochPeriod, uint256 _startTimestamp, address _kncToken) public {
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;
+        kncToken = IERC20(_kncToken);
     }
 
     function handleWithdrawal(address, uint256) public {

--- a/contracts/sol6/Dao/mock/MockMaliciousDaoReentrancy.sol
+++ b/contracts/sol6/Dao/mock/MockMaliciousDaoReentrancy.sol
@@ -7,7 +7,7 @@ import "../KyberStaking.sol";
 /// @notice Mock Malicious DAO tries to re-enter withdraw function in Staking
 contract MockMaliciousDaoReentrancy is EpochUtils {
     KyberStaking public staking;
-    IERC20 public knc;
+    IERC20 public kncToken;
 
     uint256 totalDeposit = 0;
 
@@ -20,7 +20,7 @@ contract MockMaliciousDaoReentrancy is EpochUtils {
         epochPeriodInSeconds = _epochPeriod;
         firstEpochStartTimestamp = _startTimestamp;
         staking = _staking;
-        knc = _knc;
+        kncToken = _knc;
         require(_knc.approve(address(_staking), 2**255));
     }
 

--- a/contracts/sol6/IKyberDAO.sol
+++ b/contracts/sol6/IKyberDAO.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.6.6;
 
 import "./Dao/IEpochUtils.sol";
+import "./IERC20.sol";
 
 
 interface IKyberDAO is IEpochUtils {
@@ -33,4 +34,6 @@ interface IKyberDAO is IEpochUtils {
         returns (uint256 feeInBps, uint256 expiryTimestamp);
 
     function shouldBurnRewardForEpoch(uint256 epoch) external view returns (bool);
+
+    function kncToken() external view returns (IERC20);
 }

--- a/contracts/sol6/mock/MockDAO.sol
+++ b/contracts/sol6/mock/MockDAO.sol
@@ -1,11 +1,13 @@
 pragma solidity 0.6.6;
 
+import "../IERC20.sol";
 import "../IKyberDAO.sol";
 import "../utils/Utils5.sol";
 import "../IKyberFeeHandler.sol";
 
 
 contract MockDAO is IKyberDAO, Utils5 {
+    IERC20 public override kncToken;
     IKyberFeeHandler public feeHandler;
     uint256 public rewardInBPS;
     uint256 public rebateInBPS;

--- a/contracts/sol6/mock/SimpleKyberProxy.sol
+++ b/contracts/sol6/mock/SimpleKyberProxy.sol
@@ -8,6 +8,7 @@ import "../IKyberNetworkProxy.sol";
 contract SimpleKyberProxy is IKyberNetworkProxy, Utils5 {
     using SafeERC20 for IERC20;
 
+    address public kyberNetwork;
     mapping(bytes32 => uint256) public pairRate; //rate in precision units. i.e. if rate is 10**18 its same as 1:1
 
     uint256 networkFeeBps = 25;
@@ -158,5 +159,9 @@ contract SimpleKyberProxy is IKyberNetworkProxy, Utils5 {
                 minConversionRate,
                 address(0)
             );
+    }
+
+    function setKyberNetwork(address network) external {
+        kyberNetwork = network;
     }
 }

--- a/test/sol6/kyberDao.js
+++ b/test/sol6/kyberDao.js
@@ -5828,7 +5828,7 @@ contract('KyberDAO', function(accounts) {
       Helper.assertEqual(await daoContract.numberCampaigns(), 0, "number campaign is wrong");
     });
 
-    it("Test constructor should revert staking & dao have different epoch period or start block", async function() {
+    it("Test constructor should revert staking & dao have different data", async function() {
       // different epoch period
       let stakingContract = await StakingContract.new(kncToken.address, blocksToSeconds(10), blockToTimestamp(currentBlock + 10), daoOperator);
       await expectRevert(
@@ -5849,6 +5849,17 @@ contract('KyberDAO', function(accounts) {
           daoOperator
         ),
         "ctor: diff start timestamp"
+      )
+      // knc is different from staking
+      let token = await TestToken.new("test token", "tst", 18);
+      await expectRevert(
+        DAOContract.new(
+          blocksToSeconds(10), blockToTimestamp(currentBlock + 10),
+          stakingContract.address,  feeHandler.address, token.address,
+          minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
+          daoOperator
+        ),
+        "ctor: diff knc token"
       )
       await DAOContract.new(
         blocksToSeconds(10), blockToTimestamp(currentBlock + 10),

--- a/test/sol6/kyberDao.js
+++ b/test/sol6/kyberDao.js
@@ -1384,14 +1384,14 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 9, currentBlock + 9 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3, 5000], '0x', {from: daoOperator}
         ),
-        "validateParams: Fee campaign option value is too high"
+        "validateParams: fee campaign option value is too high"
       )
       await expectRevert(
         submitNewCampaign(daoContract,
           1, currentBlock + 11, currentBlock + 11 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 10000, 2, 3], '0x', {from: daoOperator}
         ),
-        "validateParams: Fee campaign option value is too high"
+        "validateParams: fee campaign option value is too high"
       )
       await submitNewCampaign(daoContract,
         1, currentBlock + 13, currentBlock + 13 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -3508,7 +3508,7 @@ contract('KyberDAO', function(accounts) {
 
       await expectRevert(
         daoContract.claimReward(mike, 1),
-        "claimReward: No reward"
+        "claimReward: no reward"
       )
 
       await feeHandler.withdrawAllETH({from: accounts[0]});
@@ -3541,12 +3541,12 @@ contract('KyberDAO', function(accounts) {
       // no stake
       await expectRevert(
         daoContract.claimReward(poolMaster, 1),
-        "claimReward: No reward"
+        "claimReward: no reward"
       )
       // already delegated
       await expectRevert(
         daoContract.claimReward(victor, 1),
-        "claimReward: No reward"
+        "claimReward: no reward"
       )
 
       // mike has no stake, but has delegated stake
@@ -3578,7 +3578,7 @@ contract('KyberDAO', function(accounts) {
       // victor didn't vote
       await expectRevert(
         daoContract.claimReward(victor, 1),
-        "claimReward: No reward"
+        "claimReward: no reward"
       )
 
       await daoContract.claimReward(mike, 1);
@@ -3671,7 +3671,7 @@ contract('KyberDAO', function(accounts) {
 
       await expectRevert(
         daoContract.claimReward(mike, 4),
-        "claimReward: No reward"
+        "claimReward: no reward"
       )
 
       await daoContract.claimReward(mike, 1);
@@ -5838,7 +5838,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: diff epoch period"
+        "ctor: different epoch period"
       )
       // different start block
       await expectRevert(
@@ -5848,7 +5848,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: diff start timestamp"
+        "ctor: different start timestamp"
       )
       // knc is different from staking
       let token = await TestToken.new("test token", "tst", 18);
@@ -5859,7 +5859,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: diff knc token"
+        "ctor: different knc token"
       )
       await DAOContract.new(
         blocksToSeconds(10), blockToTimestamp(currentBlock + 10),
@@ -5900,7 +5900,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: staking is missing"
+        "ctor: staking 0"
       )
       // feehandler missing
       await expectRevert(
@@ -5910,7 +5910,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: feeHandler is missing"
+        "ctor: feeHandler 0"
       )
       // knc missing
       await expectRevert(
@@ -5920,7 +5920,7 @@ contract('KyberDAO', function(accounts) {
           minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
           daoOperator
         ),
-        "ctor: knc token is missing"
+        "ctor: knc token 0"
       )
       // network fee is high (>= 50%)
       await expectRevert(

--- a/test/sol6/kyberFeeHandler.js
+++ b/test/sol6/kyberFeeHandler.js
@@ -25,7 +25,7 @@ let proxy;
 let user;
 let user2;
 let daoSetter;
-let burnConfigSetter;
+let daoOperator;
 let mockDAO;
 let knc;
 let feeHandler;
@@ -47,7 +47,7 @@ contract('KyberFeeHandler', function(accounts) {
         user = accounts[9];
         user2 = accounts[8];
         daoSetter = accounts[1];
-        burnConfigSetter = accounts[2];
+        daoOperator = accounts[2];
 
         rebateWallets.push(accounts[1]);
         rebateWallets.push(accounts[2]);
@@ -78,9 +78,9 @@ contract('KyberFeeHandler', function(accounts) {
         sanityRate = await BurnKncSanityRate.new();
         await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
 
-        feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+        feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
         await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
-        await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+        await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
         await feeHandler.getBRR();
         await mockDAO.setFeeHandler(feeHandler.address);
     });
@@ -137,7 +137,7 @@ contract('KyberFeeHandler', function(accounts) {
         });
 
         it("RewardPaid", async() => {
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             let sendVal = oneEth;
             let rebateBpsPerWallet = [new BN(2000), new BN(3000), new BN(5000)];
 
@@ -208,7 +208,7 @@ contract('KyberFeeHandler', function(accounts) {
         });
 
         it("KyberDaoAddressSet", async() => {
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             let txResult = await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
             expectEvent(txResult, "KyberDaoAddressSet", {
                 kyberDAO: mockDAO.address
@@ -262,60 +262,60 @@ contract('KyberFeeHandler', function(accounts) {
         });
 
         it("BurnConfigSet", async() => {
-            let txResult = await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+            let txResult = await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
             expectEvent(txResult, "BurnConfigSet", {
                 sanityRate: sanityRate.address,
                 weiToBurn: weiToBurn
             });
-            txResult = await feeHandler.setBurnConfigParams(sanityRate.address, new BN(10000), {from: burnConfigSetter});
+            txResult = await feeHandler.setBurnConfigParams(sanityRate.address, new BN(10000), {from: daoOperator});
             expectEvent(txResult, "BurnConfigSet", {
                 sanityRate: sanityRate.address,
                 weiToBurn: new BN(10000)
             });
-            await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+            await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
         });
     });
 
     describe("should test null values in ctor arguments", async() => {
         it("daoSetter 0", async() => {
             await expectRevert(
-                FeeHandler.new(zeroAddress, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter),
+                FeeHandler.new(zeroAddress, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator),
                 "daoSetter 0"
             );
         });
 
         it("proxy 0", async() => {
             await expectRevert(
-                FeeHandler.new(daoSetter, zeroAddress, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter),
+                FeeHandler.new(daoSetter, zeroAddress, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator),
                 "KyberNetworkProxy 0"
             );
         });
 
         it("network 0", async() => {
             await expectRevert(
-                FeeHandler.new(daoSetter, proxy.address, zeroAddress, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter),
+                FeeHandler.new(daoSetter, proxy.address, zeroAddress, knc.address, BURN_BLOCK_INTERVAL, daoOperator),
                 "KyberNetwork 0"
             );
         });
 
         it("knc 0", async() => {
             await expectRevert(
-                FeeHandler.new(daoSetter, proxy.address, kyberNetwork, zeroAddress, BURN_BLOCK_INTERVAL, burnConfigSetter),
+                FeeHandler.new(daoSetter, proxy.address, kyberNetwork, zeroAddress, BURN_BLOCK_INTERVAL, daoOperator),
                 "knc 0"
             );
         });
 
         it("burnBlockInterval 0", async() => {
             await expectRevert(
-                FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, zeroBN, burnConfigSetter),
+                FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, zeroBN, daoOperator),
                 "_burnBlockInterval 0"
             );
         });
 
-        it("burnConfigSetter 0", async() => {
+        it("daoOperator 0", async() => {
             await expectRevert(
                 FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, zeroAddress),
-                "burnConfigSetter is 0"
+                "daoOperator is 0"
             );
         });
     });
@@ -355,7 +355,7 @@ contract('KyberFeeHandler', function(accounts) {
 
         it("should revert if burnBps causes overflow", async() => {
             let badDAO = await BadDAO.new(rewardInBPS, rebateInBPS, epoch, expiryTimestamp);
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             await feeHandler.setDaoContract(badDAO.address, {from: daoSetter});
             await badDAO.setFeeHandler(feeHandler.address);
             await badDAO.setMockBRR(new BN(2).pow(new BN(256)).sub(new BN(1)), BPS, new BN(1));
@@ -367,7 +367,7 @@ contract('KyberFeeHandler', function(accounts) {
 
         it("should revert if rewardBps causes overflow", async() => {
             let badDAO = await BadDAO.new(rewardInBPS, rebateInBPS, epoch, expiryTimestamp);
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             await feeHandler.setDaoContract(badDAO.address, {from: daoSetter});
             await badDAO.setFeeHandler(feeHandler.address);
             await badDAO.setMockBRR(BPS, new BN(2).pow(new BN(256)).sub(new BN(1)), new BN(1));
@@ -379,7 +379,7 @@ contract('KyberFeeHandler', function(accounts) {
 
         it("should revert if rebateBps overflows", async() => {
             let badDAO = await BadDAO.new(rewardInBPS, rebateInBPS, epoch, expiryTimestamp);
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             await feeHandler.setDaoContract(badDAO.address, {from: daoSetter});
             await badDAO.setFeeHandler(feeHandler.address);
             await badDAO.setMockBRR(BPS, new BN(1), new BN(2).pow(new BN(256)).sub(new BN(1)));
@@ -391,7 +391,7 @@ contract('KyberFeeHandler', function(accounts) {
 
         it("should revert if bad BRR values are returned", async() => {
             let badDAO = await BadDAO.new(rewardInBPS, rebateInBPS, epoch, expiryTimestamp);
-            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+            feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
             await feeHandler.setDaoContract(badDAO.address, {from: daoSetter});
             await badDAO.setFeeHandler(feeHandler.address);
             await badDAO.setMockBRR(zeroBN, zeroBN, zeroBN);
@@ -642,7 +642,7 @@ contract('KyberFeeHandler', function(accounts) {
                 let sendVal = oneEth;
                 const platformWallet = accounts[1];
                 const platformFeeWei = 0;
-                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
 
                 await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet , platformWallet, platformFeeWei,
                 {from: kyberNetwork, value: sendVal});
@@ -856,7 +856,7 @@ contract('KyberFeeHandler', function(accounts) {
 
                 let claim = precisionUnits;
 
-                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
 
                 const BRRData = await feeHandler.readBRRData();
                 currentEpoch = BRRData.epoch;
@@ -993,7 +993,7 @@ contract('KyberFeeHandler', function(accounts) {
                 const platformWallet = accounts[1];
                 const platformFeeWei = new BN(50000);
 
-                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
 
                 await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet , platformWallet, platformFeeWei,
                 {from: kyberNetwork, value: sendVal});
@@ -1058,7 +1058,7 @@ contract('KyberFeeHandler', function(accounts) {
 
                 let newWeiToBurn = maxBurn.sub(new BN(1));
 
-                await feeHandler.setBurnConfigParams(sanityRate.address, newWeiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, newWeiToBurn, {from: daoOperator});
                 await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
 
                 // expect to burn only weiToBurn
@@ -1085,7 +1085,7 @@ contract('KyberFeeHandler', function(accounts) {
 
                 let newWeiToBurn = maxBurn.add(new BN(1));
 
-                await feeHandler.setBurnConfigParams(sanityRate.address, newWeiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, newWeiToBurn, {from: daoOperator});
                 await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
 
                 // expect to burn all
@@ -1125,7 +1125,7 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts if contract has insufficient ETH for burning", async() => {
-                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 let sendVal = oneEth.mul(new BN(30));
                 let burnPerCall = await feeHandler.weiToBurn();
                 let platformWallet = accounts[9];
@@ -1176,7 +1176,7 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts no sanity rate contract", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
 
                 let sendVal = oneEth;
@@ -1195,11 +1195,11 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts sanity rate 0", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(0);
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1217,11 +1217,11 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts sanity rate > MAX_RATE", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(MAX_RATE.add(new BN(1)));
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1239,11 +1239,11 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts sanity rate and ethToKnc rate diff > MAX_DIFF of 10%", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(MAX_RATE.add(new BN(1)));
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1267,11 +1267,11 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts only none contract can call burn", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(MAX_RATE.add(new BN(1)));
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1290,9 +1290,9 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts if sanity rate is 0", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
-                await feeHandler.setBurnConfigParams(zeroAddress, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(zeroAddress, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1316,11 +1316,11 @@ contract('KyberFeeHandler', function(accounts) {
                 await proxy.setPairRate(ethAddress, badKNC.address, ethToKncPrecision);
                 await proxy.setPairRate(badKNC.address, ethAddress, kncToEthPrecision);
 
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, badKNC.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, badKNC.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 let sendVal = oneEth;
                 let platformWallet = accounts[9];
@@ -1351,7 +1351,7 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts if kyberDAO is not set", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
 
                 let platformWallet = accounts[1];
                 let platformFeeWei = oneEth;
@@ -1369,7 +1369,7 @@ contract('KyberFeeHandler', function(accounts) {
             });
 
             it("reverts if kyberDAO prevents burning of reward", async() => {
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 mockDAO = await MockDAO.new(
                     rewardInBPS,
                     rebateInBPS,
@@ -1404,7 +1404,7 @@ contract('KyberFeeHandler', function(accounts) {
                 let sendVal = oneEth;
                 const platformWallet = accounts[1];
                 const platformFeeWei = 0;
-                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await BadFeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
 
                 await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet , platformWallet, platformFeeWei,
                 {from: kyberNetwork, value: sendVal});
@@ -1426,19 +1426,19 @@ contract('KyberFeeHandler', function(accounts) {
             it("test reverts burn config params invalid", async() => {
                 // revert weiToBurn is zero
                 await expectRevert(
-                    feeHandler.setBurnConfigParams(sanityRate.address, 0, {from: burnConfigSetter}),
+                    feeHandler.setBurnConfigParams(sanityRate.address, 0, {from: daoOperator}),
                     "_weiToBurn is 0"
                 )
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
             });
 
-            it("test reverts only burnConfigSetter", async() => {
+            it("test reverts only daoOperator", async() => {
                 // revert when sanity is zero
                 await expectRevert(
                     feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: user}),
-                    "only burnConfigSetter"
+                    "only daoOperator"
                 )
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
             });
 
             it("test records correct burn config params", async() => {
@@ -1446,7 +1446,7 @@ contract('KyberFeeHandler', function(accounts) {
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
 
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 await feeHandler.getBRR();
                 await mockDAO.setFeeHandler(feeHandler.address);
@@ -1457,7 +1457,7 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(weiToBurn, recordedWeiToBurn);
 
                 // set first data
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
                 sanityRateContracts = await feeHandler.getSanityRateContracts();
                 recordedWeiToBurn = await feeHandler.weiToBurn();
                 Helper.assertEqual(1, sanityRateContracts.length);
@@ -1465,17 +1465,17 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(weiToBurn, recordedWeiToBurn);
 
                 // weiToBurn unchanges if set the same value
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
                 recordedWeiToBurn = await feeHandler.weiToBurn();
                 Helper.assertEqual(weiToBurn, recordedWeiToBurn);
 
                 // set another wei to burn value
-                await feeHandler.setBurnConfigParams(sanityRate.address, 1000, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, 1000, {from: daoOperator});
                 recordedWeiToBurn = await feeHandler.weiToBurn();
                 Helper.assertEqual(1000, recordedWeiToBurn);
 
                 // reset back
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
                 recordedWeiToBurn = await feeHandler.weiToBurn();
                 Helper.assertEqual(weiToBurn, recordedWeiToBurn);
 
@@ -1485,14 +1485,14 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(sanityRate.address, sanityRateContracts[0]);
 
                 // set different sanity rate contract, see it is updated
-                await feeHandler.setBurnConfigParams(user, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(user, weiToBurn, {from: daoOperator});
                 sanityRateContracts = await feeHandler.getSanityRateContracts();
                 Helper.assertEqual(2, sanityRateContracts.length);
                 Helper.assertEqual(user, sanityRateContracts[0]);
                 Helper.assertEqual(sanityRate.address, sanityRateContracts[1]);
 
                 // set different sanity rate contract, see list is updated with correct order
-                await feeHandler.setBurnConfigParams(user2, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(user2, weiToBurn, {from: daoOperator});
                 sanityRateContracts = await feeHandler.getSanityRateContracts();
                 Helper.assertEqual(3, sanityRateContracts.length);
                 Helper.assertEqual(user2, sanityRateContracts[0]);
@@ -1500,7 +1500,7 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(user, sanityRateContracts[2]);
 
                 // set old one, see list still inreases
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});;
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});;
                 sanityRateContracts = await feeHandler.getSanityRateContracts();
                 Helper.assertEqual(4, sanityRateContracts.length);
                 Helper.assertEqual(sanityRate.address, sanityRateContracts[0]);
@@ -1509,7 +1509,7 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(user2, sanityRateContracts[3]);
 
                 // set same as current one, nothing changes
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
                 sanityRateContracts = await feeHandler.getSanityRateContracts();
                 Helper.assertEqual(4, sanityRateContracts.length);
                 Helper.assertEqual(sanityRate.address, sanityRateContracts[0]);
@@ -1523,7 +1523,7 @@ contract('KyberFeeHandler', function(accounts) {
                 sanityRate = await BurnKncSanityRate.new();
                 await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
 
-                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+                feeHandler = await FeeHandler.new(daoSetter, proxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
                 await feeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
                 await feeHandler.getBRR();
                 await mockDAO.setFeeHandler(feeHandler.address);
@@ -1531,7 +1531,7 @@ contract('KyberFeeHandler', function(accounts) {
                 // default value is 0 when no sanity rateHelper.assertEqual(0, await feeHandler.getLatestSanityRate());
                 Helper.assertEqual(0, await feeHandler.getLatestSanityRate());
 
-                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
 
                 await sanityRate.setLatestKncToEthRate(0);
                 Helper.assertEqual(0, await feeHandler.getLatestSanityRate());
@@ -1544,7 +1544,7 @@ contract('KyberFeeHandler', function(accounts) {
 
                 // change new sanity rate
                 let newSanity = await BurnKncSanityRate.new();
-                await feeHandler.setBurnConfigParams(newSanity.address, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(newSanity.address, weiToBurn, {from: daoOperator});
 
                 Helper.assertEqual(0, await feeHandler.getLatestSanityRate());
                 await newSanity.setLatestKncToEthRate(10000);
@@ -1558,78 +1558,8 @@ contract('KyberFeeHandler', function(accounts) {
                 Helper.assertEqual(kncToEthPrecision, await feeHandler.getLatestSanityRate());
 
                 // set sanity rate to 0
-                await feeHandler.setBurnConfigParams(zeroAddress, weiToBurn, {from: burnConfigSetter});
+                await feeHandler.setBurnConfigParams(zeroAddress, weiToBurn, {from: daoOperator});
                 Helper.assertEqual(0, await feeHandler.getLatestSanityRate());
-            });
-
-            it("test transfer burnConfigSetter", async() => {
-                Helper.assertEqual(burnConfigSetter, await feeHandler.burnConfigSetter());
-                Helper.assertEqual(zeroAddress, await feeHandler.pendingBurnConfigSetter());
-
-                // can not transfer, only currnet burn config setter
-                await expectRevert(
-                    feeHandler.transferBurnConfigSetter(user, {from: user}),
-                    "only burnConfigSetter"
-                )
-                await expectRevert(
-                    feeHandler.transferBurnConfigSetter(user, {from: user2}),
-                    "only burnConfigSetter"
-                )
-                // new setter is 0
-                await expectRevert(
-                    feeHandler.transferBurnConfigSetter(zeroAddress, {from: burnConfigSetter}),
-                    "newSetter is 0"
-                )
-
-                // can not claim pending setter when it is zero
-                await expectRevert(
-                    feeHandler.claimBurnConfigSetter({from: user}),
-                    "only pending burn config setter"
-                )
-
-                // transfer
-                let txResult = await feeHandler.transferBurnConfigSetter(user, {from: burnConfigSetter});
-                // check event
-                expectEvent(txResult, 'TransferBurnConfigSetter', {
-                    pendingBurnConfigSetter: user
-                });
-
-                // check current setter and pending setter
-                Helper.assertEqual(burnConfigSetter, await feeHandler.burnConfigSetter());
-                Helper.assertEqual(user, await feeHandler.pendingBurnConfigSetter());
-
-                // check user's still unable to set config
-                await expectRevert(
-                    feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: user}),
-                    "only burnConfigSetter"
-                )
-
-                // test can not claim pending setter
-                await expectRevert(
-                    feeHandler.claimBurnConfigSetter({from: burnConfigSetter}),
-                    "only pending burn config setter"
-                )
-
-                txResult = await feeHandler.claimBurnConfigSetter({from: user});
-                // check event
-                expectEvent(txResult, 'BurnConfigSetterClaimed', {
-                    newBurnConfigSetter: user,
-                    previousBurnConfigSetter: burnConfigSetter
-                });
-
-                // check current setter and pending setter
-                Helper.assertEqual(user, await feeHandler.burnConfigSetter());
-                Helper.assertEqual(zeroAddress, await feeHandler.pendingBurnConfigSetter());
-
-                // check old setter can not set burn config params anymore
-                await expectRevert(
-                    feeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: burnConfigSetter}),
-                    "only burnConfigSetter"
-                )
-                // check user now can set data, and data changes
-                await feeHandler.setBurnConfigParams(user, 1000, {from: user});
-                Helper.assertEqual(user, (await feeHandler.getSanityRateContracts())[0]);
-                Helper.assertEqual(1000, await feeHandler.weiToBurn());
             });
         });
     });
@@ -1639,20 +1569,131 @@ contract('KyberFeeHandler', function(accounts) {
         storage = accounts[8];
         tempNetwork = await KyberNetwork.new(admin, storage);
         tempProxy = await KyberNetworkProxy.new(admin);
-        tempFeeHandler = await FeeHandler.new(daoSetter, tempProxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, burnConfigSetter);
+        tempFeeHandler = await FeeHandler.new(daoSetter, tempProxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
         Helper.assertEqual(kyberNetwork, await tempFeeHandler.kyberNetwork(), "network does not match");
         await expectRevert(
-            tempFeeHandler.updateNetworkContract(), "only burnConfigSetter"
+            tempFeeHandler.updateNetworkContract(), "only daoOperator"
         )
         await expectRevert(
-            tempFeeHandler.updateNetworkContract({from: burnConfigSetter}), "KyberNetwork 0"
+            tempFeeHandler.updateNetworkContract({from: daoOperator}), "KyberNetwork 0"
         )
         await tempProxy.setKyberNetwork(tempNetwork.address, {from: admin});
-        txResult = await tempFeeHandler.updateNetworkContract({from: burnConfigSetter});
+        txResult = await tempFeeHandler.updateNetworkContract({from: daoOperator});
         expectEvent(txResult, 'KyberNetworkUpdated', {
             kyberNetwork: tempNetwork.address,
         });
         Helper.assertEqual(tempNetwork.address, await tempFeeHandler.kyberNetwork(), "network does not match");
+    });
+
+    describe("Update Network Proxy", async() => {
+        it("Test should revert new proxy is 0", async() => {
+            await expectRevert(
+                feeHandler.setNetworkProxy(zeroAddress, {from: daoOperator}),
+                "new proxy is 0"
+            )
+        })
+
+        it("Test should revert new proxy is not a contract", async() => {
+            await expectRevert.unspecified(
+                feeHandler.setNetworkProxy(accounts[2], {from: daoOperator})
+            )
+        })
+
+        // update proxy will also update network address
+        it("Test should revert new proxy has no network contract", async() => {
+            let proxy = await KyberNetworkProxy.new(accounts[0]);
+            await expectRevert(
+                feeHandler.setNetworkProxy(proxy.address, {from: daoOperator}),
+                "KyberNetwork 0"
+            )
+        })
+
+        it("Test should revert not burn config", async() => {
+            await expectRevert(
+                feeHandler.setNetworkProxy(accounts[0], {from: accounts[0]}),
+                "only daoOperator"
+            )
+        })
+
+        it("Test update with event", async() => {
+            let newProxy = await KyberNetworkProxy.new(accounts[0]);
+            await newProxy.setKyberNetwork(accounts[1]);
+            let txResult = await feeHandler.setNetworkProxy(newProxy.address, {from: daoOperator});
+            expectEvent(txResult, "KyberProxyUpdated", {
+                newProxy: newProxy.address,
+                oldProxy: proxy.address
+            })
+            expectEvent(txResult, "KyberNetworkUpdated", {
+                kyberNetwork: accounts[1]
+            })
+            let anotherProxy = await KyberNetworkProxy.new(accounts[0]);
+            await anotherProxy.setKyberNetwork(accounts[2]);
+            txResult = await feeHandler.setNetworkProxy(anotherProxy.address, {from: daoOperator});
+            expectEvent(txResult, "KyberProxyUpdated", {
+                newProxy: anotherProxy.address,
+                oldProxy: newProxy.address
+            })
+            expectEvent(txResult, "KyberNetworkUpdated", {
+                kyberNetwork: accounts[2]
+            })
+        });
+
+        it("Test update network after update proxy", async() => {
+            let admin = accounts[1];
+            let storage = accounts[8];
+            let tempNetwork = await KyberNetwork.new(admin, storage);
+            let tempProxy = await KyberNetworkProxy.new(admin);
+            let tempFeeHandler = await FeeHandler.new(daoSetter, tempProxy.address, kyberNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
+            await tempFeeHandler.setNetworkProxy(tempProxy.address, {from: daoOperator});
+            await tempProxy.setKyberNetwork(accounts[0], {from: admin});
+            await tempFeeHandler.updateNetworkContract({from: daoOperator});
+            Helper.assertEqual(accounts[0], await tempFeeHandler.kyberNetwork(), "network does not match");
+            await tempProxy.setKyberNetwork(tempNetwork.address, {from: admin});
+            await tempFeeHandler.updateNetworkContract({from: daoOperator});
+            Helper.assertEqual(tempNetwork.address, await tempFeeHandler.kyberNetwork(), "network does not match");
+        })
+
+        it("Test burn KNC after updating proxy", async() => {
+            let admin = accounts[1];
+            let tempNetwork = accounts[0];
+
+            let sanityRate = await BurnKncSanityRate.new();
+            await sanityRate.setLatestKncToEthRate(kncToEthPrecision);
+
+            let tempProxy = await Proxy.new();
+            await tempProxy.setKyberNetwork(accounts[0]);
+            await knc.transfer(tempProxy.address, oneKnc.mul(new BN(10000)));
+            await Helper.sendEtherWithPromise(accounts[9], tempProxy.address, oneEth);
+
+            await tempProxy.setPairRate(ethAddress, knc.address, ethToKncPrecision);
+            await tempProxy.setPairRate(knc.address, ethAddress, kncToEthPrecision);
+
+            let tempFeeHandler = await FeeHandler.new(daoSetter, tempProxy.address, tempNetwork, knc.address, BURN_BLOCK_INTERVAL, daoOperator);
+            await tempFeeHandler.setDaoContract(mockDAO.address, {from: daoSetter});
+            await tempFeeHandler.setBurnConfigParams(sanityRate.address, weiToBurn, {from: daoOperator});
+            await tempFeeHandler.getBRR();
+            await tempFeeHandler.setNetworkProxy(tempProxy.address, {from: daoOperator});
+
+            await tempFeeHandler.handleFees([], [], zeroAddress, 0, {from: tempNetwork, value: oneEth});
+            await tempFeeHandler.burnKnc();
+
+            await Helper.increaseBlockNumber(BURN_BLOCK_INTERVAL);
+
+            // new proxy
+            tempProxy = await Proxy.new();
+            await tempProxy.setKyberNetwork(accounts[1]);
+            await knc.transfer(tempProxy.address, oneKnc.mul(new BN(10000)));
+            await Helper.sendEtherWithPromise(accounts[9], tempProxy.address, oneEth);
+            await tempProxy.setPairRate(ethAddress, knc.address, ethToKncPrecision);
+            await tempProxy.setPairRate(knc.address, ethAddress, kncToEthPrecision);
+
+            await tempFeeHandler.handleFees([], [], zeroAddress, 0, {from: tempNetwork, value: oneEth});
+
+            // set new proxy for fee handler
+            await tempFeeHandler.setNetworkProxy(tempProxy.address, {from: daoOperator});
+            // burn knc
+            await tempFeeHandler.burnKnc();
+        });
     });
 });
 

--- a/test/sol6/kyberIntegration.js
+++ b/test/sol6/kyberIntegration.js
@@ -280,7 +280,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         await networkStorage.setNetworkContract(network.address, {from: admin});
         await matchingEngine.setNetworkContract(network.address, {from: admin});
         await networkProxy.setKyberNetwork(network.address, {from: admin});
-        await feeHandler.updateNetworkContract({from: daoSetter});
+        await feeHandler.setNetworkContract(network.address, {from: daoSetter});
 
         //setup network
         ///////////////
@@ -333,7 +333,7 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         await network.setEnable(true, {from: admin});
 
         //update  network contract
-        await feeHandler.updateNetworkContract({from: daoSetter});
+        await feeHandler.setNetworkContract(network.address, {from: daoSetter});
 
         await updateCurrentBlockAndTimestamp();
     };

--- a/test/sol6/kyberStaking.js
+++ b/test/sol6/kyberStaking.js
@@ -74,7 +74,8 @@ contract('KyberStaking', function(accounts) {
     await deployStakingContract(10, currentBlock + 10);
     let daoContract = await MockKyberDAO.new(
       blocksToSeconds(10),
-      blockToTimestamp(currentBlock + 10)
+      blockToTimestamp(currentBlock + 10),
+      kncToken.address
     );
 
     assert.equal(daoSetter, await stakingContract.daoContractSetter(), "daoSetter address is wrong");
@@ -1052,6 +1053,7 @@ contract('KyberStaking', function(accounts) {
       let dao = await MockKyberDAO.new(
         blocksToSeconds(10),
         blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
 
@@ -1130,6 +1132,7 @@ contract('KyberStaking', function(accounts) {
       let dao = await MockKyberDAO.new(
         blocksToSeconds(10),
         blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
 
@@ -1149,6 +1152,7 @@ contract('KyberStaking', function(accounts) {
       let dao = await MockKyberDAO.new(
         blocksToSeconds(10),
         blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
 
       await kncToken.transfer(victor, mulPrecision(500));
@@ -2326,7 +2330,8 @@ contract('KyberStaking', function(accounts) {
       await deployStakingContract(10, currentBlock + 10);
       let dao = await MockKyberDAO.new(
         blocksToSeconds(10),
-        blockToTimestamp(currentBlock + 10)
+        blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(zeroAddress, {from: daoSetter}),
@@ -2343,11 +2348,12 @@ contract('KyberStaking', function(accounts) {
       )
     });
 
-    it("Test update DAO address should revert when epoch period or start timestamp is different between staking & DAO", async function() {
+    it("Test update DAO address should revert when data is different between staking & DAO", async function() {
       await deployStakingContract(10, currentBlock + 10);
       let dao = await MockKyberDAO.new(
         blocksToSeconds(9),
-        blockToTimestamp(currentBlock + 10)
+        blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
 
       // revert different epoch number
@@ -2358,7 +2364,8 @@ contract('KyberStaking', function(accounts) {
 
       dao = await MockKyberDAO.new(
         blocksToSeconds(10),
-        blockToTimestamp(currentBlock + 9)
+        blockToTimestamp(currentBlock + 9),
+        kncToken.address
       );
       // revert different start timestamp number
       await expectRevert(
@@ -2366,9 +2373,22 @@ contract('KyberStaking', function(accounts) {
         "updateDAO: DAO and Staking have different start timestamp"
       )
 
+      let token = await TestToken.new("test token", "tst", 18);
       dao = await MockKyberDAO.new(
         blocksToSeconds(10),
-        blockToTimestamp(currentBlock + 10)
+        blockToTimestamp(currentBlock + 10),
+        token.address
+      );
+      // revert different knc token
+      await expectRevert(
+        stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter}),
+        "updateDAO: DAO and Staking have different knc token"
+      )
+
+      dao = await MockKyberDAO.new(
+        blocksToSeconds(10),
+        blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
     });
@@ -2658,7 +2678,8 @@ contract('KyberStaking', function(accounts) {
       await deployStakingContract(10, currentBlock + 10);
       let dao = await MockDAOWithdrawFailed.new(
         blocksToSeconds(10),
-        blockToTimestamp(currentBlock + 10)
+        blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
 
@@ -2681,7 +2702,8 @@ contract('KyberStaking', function(accounts) {
       await deployStakingContract(10, currentBlock + 10);
       let dao = await MockDAOWithdrawFailed.new(
         blocksToSeconds(10),
-        blockToTimestamp(currentBlock + 10)
+        blockToTimestamp(currentBlock + 10),
+        kncToken.address
       );
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
 

--- a/test/sol6/kyberStaking.js
+++ b/test/sol6/kyberStaking.js
@@ -93,7 +93,7 @@ contract('KyberStaking', function(accounts) {
 
     await expectRevert(
       stakingContract.updateDAOAddressAndRemoveSetter(daoContract.address, {from: daoSetter}),
-      "sender is not daoContractSetter"
+      "only daoContractSetter"
     );
   });
 
@@ -1142,7 +1142,7 @@ contract('KyberStaking', function(accounts) {
 
       await expectRevert(
         stakingContract.handleWithdrawal(victor, mulPrecision(100), 0),
-        "only staking contract can call this function"
+        "only staking contract"
       )
       await stakingContract.withdraw(mulPrecision(100), {from: victor});
     });
@@ -2335,16 +2335,16 @@ contract('KyberStaking', function(accounts) {
       );
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(zeroAddress, {from: daoSetter}),
-        "updateDAO: DAO address is missing"
+        "updateDAO: daoAddress 0"
       );
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: mike}),
-        "sender is not daoContractSetter"
+        "only daoContractSetter"
       )
       await stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter});
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter}),
-        "sender is not daoContractSetter"
+        "only daoContractSetter"
       )
     });
 
@@ -2359,7 +2359,7 @@ contract('KyberStaking', function(accounts) {
       // revert different epoch number
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter}),
-        "updateDAO: DAO and Staking have different epoch period"
+        "updateDAO: different epoch period"
       )
 
       dao = await MockKyberDAO.new(
@@ -2370,7 +2370,7 @@ contract('KyberStaking', function(accounts) {
       // revert different start timestamp number
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter}),
-        "updateDAO: DAO and Staking have different start timestamp"
+        "updateDAO: different start timestamp"
       )
 
       let token = await TestToken.new("test token", "tst", 18);
@@ -2382,7 +2382,7 @@ contract('KyberStaking', function(accounts) {
       // revert different knc token
       await expectRevert(
         stakingContract.updateDAOAddressAndRemoveSetter(dao.address, {from: daoSetter}),
-        "updateDAO: DAO and Staking have different knc token"
+        "updateDAO: different knc token"
       )
 
       dao = await MockKyberDAO.new(
@@ -2402,7 +2402,7 @@ contract('KyberStaking', function(accounts) {
           blockToTimestamp(currentBlock + 10),
           daoSetter
         ),
-        "ctor: KNC address is missing"
+        "ctor: kncToken 0"
       );
       // epoch period is 0
       await expectRevert(
@@ -2412,7 +2412,7 @@ contract('KyberStaking', function(accounts) {
           blockToTimestamp(currentBlock + 10),
           daoSetter
         ),
-        "ctor: epoch duration must be positive"
+        "ctor: epoch period is 0"
       )
       // start timestamp is in the past
       await expectRevert(
@@ -2422,7 +2422,7 @@ contract('KyberStaking', function(accounts) {
           blockToTimestamp(currentBlock - 1),
           daoSetter
         ),
-        "ctor: start timestamp should not be in the past"
+        "ctor: start in the past"
       )
       // dao setter is 0
       await expectRevert(
@@ -2432,7 +2432,7 @@ contract('KyberStaking', function(accounts) {
           blockToTimestamp(currentBlock + 10),
           zeroAddress
         ),
-        "ctor: daoContractSetter address is missing"
+        "ctor: daoContractSetter 0"
       )
       stakingContract = await StakingContract.new(
         kncToken.address,
@@ -2497,16 +2497,16 @@ contract('KyberStaking', function(accounts) {
       await deployStakingContract(10, currentBlock + 10);
       await expectRevert(
         stakingContract.initAndReturnStakerDataForCurrentEpoch(mike, {from: mike}),
-        "initAndReturnData: sender is not DAO address"
+        "initAndReturnData: only daoContract"
       )
       await expectRevert(
         stakingContract.initAndReturnStakerDataForCurrentEpoch(mike, {from: daoSetter}),
-        "initAndReturnData: sender is not DAO address"
+        "initAndReturnData: only daoContract"
       )
       await stakingContract.setDAOAddressWithoutCheck(mike, {from: daoSetter});
       await expectRevert(
         stakingContract.initAndReturnStakerDataForCurrentEpoch(mike, {from: daoSetter}),
-        "initAndReturnData: sender is not DAO address"
+        "initAndReturnData: only daoContract"
       )
       await stakingContract.initAndReturnStakerDataForCurrentEpoch(mike, {from: mike});
     });
@@ -2594,7 +2594,7 @@ contract('KyberStaking', function(accounts) {
 
       await expectRevert(
         stakingContract.delegate(zeroAddress, {from: victor}),
-        "delegate: delegated address should not be 0x0"
+        "delegate: delegated address 0"
       )
       await stakingContract.delegate(mike, {from: victor});
     });


### PR DESCRIPTION
Changes:
- Add update network proxy contract in FeeHandler, not using proxy to update network address
- Add DaoOperator to handle setting up data in FeeHandler and managing campaigns in KyberDao
- Check same KNC token in both Staking + DAO contracts

reminder: merge with this commit - https://github.com/tranvictor/smart-contracts/commit/20e9af148a4eb847a4954670d28c6dbf1643d31e. 
which inserts campaign creator and burn config setter into the contract.