### PR TITLE
Move handleChange to end of trade flow

### DIFF
--- a/contracts/sol6/KyberNetwork.sol
+++ b/contracts/sol6/KyberNetwork.sol
@@ -623,15 +623,6 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
             // notice tradeData passed by reference and updated
             destAmount = tradeData.input.maxDestAmount;
             actualSrcAmount = calcTradeSrcAmountFromDest(tradeData);
-
-            require(
-                handleChange(
-                    tradeData.input.src,
-                    tradeData.input.srcAmount,
-                    actualSrcAmount,
-                    tradeData.input.trader
-                )
-            );
         } else {
             actualSrcAmount = tradeData.input.srcAmount;
         }
@@ -657,6 +648,15 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
                 tradeData.input.destAddress,
                 tradeData,
                 destAmount
+            )
+        );
+
+        require(
+            handleChange(
+                tradeData.input.src,
+                tradeData.input.srcAmount,
+                actualSrcAmount,
+                tradeData.input.trader
             )
         );
 


### PR DESCRIPTION
- Move `handleChange` to end of trade flow, so that `handleChange` not trigger any rate change before doReserveTrade