### PR TITLE
add EmergencyFeeHandler

### DIFF
--- a/contracts/sol6/Dao/EmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/EmergencyFeeHandler.sol
@@ -77,7 +77,7 @@ contract EmergencyKyberFeeHandler is IKyberFeeHandler, PermissionGroupsNoModifie
         address platformWallet,
         uint256 platformFee,
         uint256 networkFee
-    ) external payable override onlyKyberNetwork {
+    ) external payable override onlyKyberNetwork nonReentrant {
         require(token == ETH_TOKEN_ADDRESS, "token not eth");
         require(msg.value == platformFee.add(networkFee), "msg.value not equal to total fees");
 
@@ -180,7 +180,7 @@ contract EmergencyKyberFeeHandler is IKyberFeeHandler, PermissionGroupsNoModifie
         require(amount <= balance.sub(totalPlatformFeeWei), "amount > available funds");
 
         (bool success, ) = sendTo.call{value: amount}("");
-        require(success);
+        require(success, "withdraw transfer failed");
         emit EtherWithdraw(amount, sendTo);
     }
 

--- a/contracts/sol6/Dao/EmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/EmergencyFeeHandler.sol
@@ -1,0 +1,201 @@
+pragma solidity 0.6.6;
+
+import "../IKyberFeeHandler.sol";
+import "../utils/PermissionGroupsNoModifiers.sol";
+import "../utils/zeppelin/ReentrancyGuard.sol";
+import "../utils/zeppelin/SafeMath.sol";
+import "../utils/Utils5.sol";
+
+contract EmergencyKyberFeeHandler is IKyberFeeHandler, PermissionGroupsNoModifiers, ReentrancyGuard, Utils5 {
+    using SafeMath for uint256;
+
+    uint16 public immutable rewardBps;
+    uint16 public immutable rebateBps;
+    address public kyberNetwork;
+
+    mapping(address => uint256) public feePerPlatformWallet;
+    uint256 public totalPlatformFeeWei; // total balance in the contract that is for platform fee
+    mapping(address => uint256) public rebatePerWallet;
+    uint256 public totalRewardWei;
+
+    event HandleFeeFailed(address[] rebateWallets, uint256[] rebateBpsPerWallet, uint256 feeBRRWei);
+
+    event HandleFee(
+        address indexed platformWallet,
+        uint256 platformFeeWei,
+        address[] rebateWallets,
+        uint256[] rebateBpsPerWallet,
+        uint256 feeBRRWei
+    );
+
+    event BRRFeeDistribution (
+        uint256 rewardWei,
+        uint256 rebateWei,
+        uint256 burnAmountWei
+    );
+
+    event EtherWithdraw(uint256 amount, address sendTo);
+
+    event KyberNetworkUpdated(address kyberNetwork);
+
+    constructor(
+        address admin,
+        address _kyberNetwork,
+        uint256 _rewardBps,
+        uint256 _rebateBps,
+        uint256 _burnBps
+    ) public PermissionGroupsNoModifiers(admin) {
+        require(_burnBps.add(_rewardBps).add(_rebateBps) == BPS, "Bad BRR values");
+        rewardBps = uint16(_rewardBps);
+        rebateBps = uint16(_rebateBps);
+        kyberNetwork = _kyberNetwork;
+    }
+
+    modifier onlyKyberNetwork {
+        require(msg.sender == address(kyberNetwork), "only kyberNetwork");
+        _;
+    }
+
+    /// @dev handleFees function is called per trade on KyberNetwork. unless the trade is not involving any fees.
+    /// @param rebateWallets a list of rebate wallets that will get rebate for this trade.
+    /// @param rebateBpsPerWallet percentage of rebate for each wallet, out of total rebate.
+    /// @param platformWallet Wallet address that will receive the platfrom fee.
+    /// @param platformFeeWei Fee amount in wei the platfrom wallet is entitled to.
+    function handleFees(
+        address[] calldata rebateWallets,
+        uint256[] calldata rebateBpsPerWallet,
+        address platformWallet,
+        uint256 platformFeeWei
+    ) external payable override onlyKyberNetwork {
+        uint256 feeBRRWei = msg.value.sub(platformFeeWei);
+
+        // handle platform fee
+        feePerPlatformWallet[platformWallet] = feePerPlatformWallet[platformWallet].add(
+            platformFeeWei
+        );
+        totalPlatformFeeWei = totalPlatformFeeWei.add(platformFeeWei);
+        emit HandleFee(platformWallet, platformFeeWei, rebateWallets, rebateBpsPerWallet, feeBRRWei);
+
+        if (feeBRRWei == 0) {
+            return;
+        }
+
+        (bool success, ) = address(this).call(
+            abi.encodeWithSignature(
+                "calculateAndRecordFeeData(address[],uint256[],uint256)",
+                rebateWallets,
+                rebateBpsPerWallet,
+                feeBRRWei
+            )
+        );
+        if (!success) {
+            emit HandleFeeFailed(rebateWallets, rebateBpsPerWallet, feeBRRWei);
+        }
+    }
+
+    function calculateAndRecordFeeData(
+        address[] calldata rebateWallets,
+        uint256[] calldata rebateBpsPerWallet,
+        uint256 feeBRRWei
+    ) external virtual {
+        require(msg.sender == address(this), "only Feehandler contract can call this function");
+        uint256 rebateWei = feeBRRWei.mul(rebateBps).div(BPS);
+        uint256 rewardWei = feeBRRWei.mul(rewardBps).div(BPS);
+
+        rebateWei = updateRebateValues(rebateWei, rebateWallets, rebateBpsPerWallet);
+
+        totalRewardWei = totalRewardWei.add(rewardWei);
+
+        uint burnAmountWei = feeBRRWei.sub(rewardWei).sub(rebateWei);
+
+        emit BRRFeeDistribution(
+            rewardWei,
+            rebateWei,
+            burnAmountWei
+        );
+    }
+
+    /// @dev claim accumulated fee per platform wallet. Called by any address
+    /// @param platformWallet the wallet to claim fee for. Total accumulated fee sent to this wallet.
+    /// @return amountWei amount of fee claimed
+    function claimPlatformFee(address platformWallet)
+        external
+        override
+        nonReentrant
+        returns (uint256 amountWei)
+    {
+        require(feePerPlatformWallet[platformWallet] > 1, "no fee to claim");
+        // Get total amount of fees accumulated
+        amountWei = feePerPlatformWallet[platformWallet].sub(1);
+
+        // redundant check, but can't happen
+        assert(totalPlatformFeeWei >= amountWei);
+        totalPlatformFeeWei = totalPlatformFeeWei.sub(amountWei);
+
+        feePerPlatformWallet[platformWallet] = 1; // avoid zero to non zero storage cost
+
+        (bool success, ) = platformWallet.call{value: amountWei}("");
+        require(success, "platform fee transfer failed");
+
+        emit PlatformFeePaid(platformWallet, amountWei);
+        return amountWei;
+    }
+
+    function withdraw(address payable sendTo, uint256 amount) external nonReentrant {
+        onlyAdmin();
+
+        uint256 balance = address(this).balance;
+        // check if the remain balance is enough for withdraw and paying platform fee
+        require(amount <= balance.sub(totalPlatformFeeWei), "amount > available funds");
+
+        (bool success, ) = sendTo.call{value: amount}("");
+        require(success);
+        emit EtherWithdraw(amount, sendTo);
+    }
+
+    /// @dev claimReserveRebate is implemented for IKyberFeeHandler
+    function claimReserveRebate(address) external override returns (uint256) {
+        revert("not implemented");
+    }
+
+    /// @dev claimStakerReward is implemented for IKyberFeeHandler
+    function claimStakerReward(address, uint256, uint256) external override returns (uint256) {
+        revert("not implemented");
+    }
+
+    /// @dev set new kyberNetwork address by daoOperator
+    /// @param _kyberNetwork new kyberNetwork contract
+    function setNetworkContract(address _kyberNetwork) external {
+        onlyAdmin();
+        require(_kyberNetwork != address(0), "kyberNetwork 0");
+        if (_kyberNetwork != kyberNetwork) {
+            kyberNetwork = _kyberNetwork;
+            emit KyberNetworkUpdated(kyberNetwork);
+        }
+    }
+
+    function updateRebateValues(
+        uint256 rebateWei,
+        address[] memory rebateWallets,
+        uint256[] memory rebateBpsPerWallet
+    ) internal returns (uint256 totalRebatePaidWei) {
+        uint256 totalRebateBps;
+        uint256 walletRebateWei;
+
+        for (uint256 i = 0; i < rebateWallets.length; i++) {
+            require(rebateWallets[i] != address(0), "rebate wallet address 0");
+
+            walletRebateWei = rebateWei.mul(rebateBpsPerWallet[i]).div(BPS);
+            rebatePerWallet[rebateWallets[i]] = rebatePerWallet[rebateWallets[i]].add(
+                walletRebateWei
+            );
+
+            // a few wei could be left out due to rounding down. so count only paid wei
+            totalRebatePaidWei = totalRebatePaidWei.add(walletRebateWei);
+            totalRebateBps = totalRebateBps.add(rebateBpsPerWallet[i]);
+        }
+
+        require(totalRebateBps <= BPS, "rebates more then 100%");
+    }
+
+}

--- a/contracts/sol6/Dao/emergency/EmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/emergency/EmergencyFeeHandler.sol
@@ -1,12 +1,18 @@
 pragma solidity 0.6.6;
 
-import "../IKyberFeeHandler.sol";
-import "../utils/PermissionGroupsNoModifiers.sol";
-import "../utils/zeppelin/ReentrancyGuard.sol";
-import "../utils/zeppelin/SafeMath.sol";
-import "../utils/Utils5.sol";
-import "@nomiclabs/buidler/console.sol";
+import "../../IKyberFeeHandler.sol";
+import "../../utils/PermissionGroupsNoModifiers.sol";
+import "../../utils/zeppelin/ReentrancyGuard.sol";
+import "../../utils/zeppelin/SafeMath.sol";
+import "../../utils/Utils5.sol";
 
+/**
+ * @title kyberFeeHandler
+ *
+ * @dev EmergencyFeeHandler works when dao has problem
+ *      rebateBps and rewardBps is only set when initialization
+ *      user can claim platformfee, rebate and reward will be distributed by admin
+ */
 contract EmergencyKyberFeeHandler is IKyberFeeHandler, PermissionGroupsNoModifiers, ReentrancyGuard, Utils5 {
     using SafeMath for uint256;
 

--- a/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.6.6;
 
-import "../EmergencyFeeHandler.sol";
-
+import "../emergency/EmergencyFeeHandler.sol";
 
 contract MockEmergencyFeeHandler is EmergencyKyberFeeHandler {
     constructor(

--- a/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.6.6;
+
+import "../EmergencyFeeHandler.sol";
+
+
+contract MockEmergencyFeeHandler is EmergencyKyberFeeHandler {
+    constructor(
+        address admin,
+        address _kyberNetwork,
+        uint256 _rewardBps,
+        uint256 _rebateBps,
+        uint256 _burnBps
+    ) public EmergencyKyberFeeHandler(admin, _kyberNetwork, _rewardBps, _rebateBps, _burnBps) {}
+
+    function calculateAndRecordFeeData(
+        address[] calldata,
+        uint256[] calldata,
+        uint256
+    ) external override {
+        revert();
+    }
+}

--- a/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
+++ b/contracts/sol6/Dao/mock/MockEmergencyFeeHandler.sol
@@ -13,6 +13,8 @@ contract MockEmergencyFeeHandler is EmergencyKyberFeeHandler {
     ) public EmergencyKyberFeeHandler(admin, _kyberNetwork, _rewardBps, _rebateBps, _burnBps) {}
 
     function calculateAndRecordFeeData(
+        address,
+        uint256,
         address[] calldata,
         uint256[] calldata,
         uint256

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,9 +394,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -416,23 +416,17 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
         }
       }
     },
     "@openzeppelin/test-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/test-helpers/-/test-helpers-0.5.5.tgz",
-      "integrity": "sha512-jTSCQojQ0Q7FBMN3Me7o0OIVuRnfHRR9TcE+ZlfbSfdqrHkFLwSfeDHSNWtQGlF1xPQR5r3iRI0ccsCrN+JblA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/test-helpers/-/test-helpers-0.5.6.tgz",
+      "integrity": "sha512-8U4sR4ed4cFmc6UKj7akUxZzQJKU9P3p/3RbF+urQuRLLhBaB8zSya1m9VB7/anYEZnBmTDk8LuVgAmYaCPs9A==",
       "dev": true,
       "requires": {
         "@openzeppelin/contract-loader": "^0.4.0",
-        "@truffle/contract": "^4.0.35",
+        "@truffle/contract": "^4.0.35 <4.2.2",
         "ansi-colors": "^3.2.3",
         "chai": "^4.2.0",
         "chai-bn": "^0.2.1",
@@ -566,13 +560,13 @@
       }
     },
     "@truffle/contract": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.1.13.tgz",
-      "integrity": "sha512-LLtRU4rRBd9jw/ngpYKwr++pEzdR64/vu2UjSxeizP1wIDm1XAIJ7BH2QiWh4PV2i44KzAfgvPtOwgbwr2hvdw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.1.tgz",
+      "integrity": "sha512-af1rUyU/W75GYHt/i7r+NwHozwaCma7V/q/+SRZ3Cw2MFaGOQ0dA/ZGhH8P1F0fmDiUe1DBEIbKxXWai0PWFYg==",
       "dev": true,
       "requires": {
         "@truffle/blockchain-utils": "^0.0.18",
-        "@truffle/contract-schema": "^3.0.23",
+        "@truffle/contract-schema": "^3.1.0",
         "@truffle/error": "^0.0.8",
         "@truffle/interface-adapter": "^0.4.6",
         "bignumber.js": "^7.2.1",
@@ -586,38 +580,6 @@
         "web3-utils": "1.2.1"
       },
       "dependencies": {
-        "@truffle/blockchain-utils": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.18.tgz",
-          "integrity": "sha512-XnRu5p1QO9krJizOeBY5WfzPDvEOmCnOT5u6qF8uN3Kkq9vcH3ZqW4XTuzz9ERZNpZfWb3UJx4PUosgeHLs5vw==",
-          "dev": true,
-          "requires": {
-            "source-map-support": "^0.5.16"
-          }
-        },
-        "@truffle/contract-schema": {
-          "version": "3.0.23",
-          "resolved": "https://registry.npmjs.org/@truffle/contract-schema/-/contract-schema-3.0.23.tgz",
-          "integrity": "sha512-N4CaTMcZhOC44Vl6k2r/eua+ojUswl6mNlkVTVYMvWjfKa8GHKKClsZfkGO72aBrBzoTFsM6D75LvQIIRBy3fg==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.10.0",
-            "crypto-js": "^3.1.9-1",
-            "debug": "^4.1.0"
-          }
-        },
-        "@truffle/interface-adapter": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.4.6.tgz",
-          "integrity": "sha512-FZAUb7tx/7VbxpAbo70+K2v22j1O7y4BwhWypRwYpf1YbE2C1OCo/L8zInaW5LfzRd2BEsfb2GjUgbK9VaFrDA==",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethers": "^4.0.32",
-            "source-map-support": "^0.5.16",
-            "web3": "1.2.1"
-          }
-        },
         "bignumber.js": {
           "version": "7.2.1",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
@@ -633,20 +595,6 @@
             "bn.js": "^4.11.6",
             "elliptic": "^6.4.0",
             "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "ethereum-ens": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.8.0.tgz",
-          "integrity": "sha512-a8cBTF4AWw1Q1Y37V1LSCS9pRY4Mh3f8vCg5cbXCCEJ3eno1hbI/+Ccv9SZLISYpqQhaglP3Bxb/34lS4Qf7Bg==",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.4.7",
-            "eth-ens-namehash": "^2.0.0",
-            "js-sha3": "^0.5.7",
-            "pako": "^1.0.4",
-            "underscore": "^1.8.3",
-            "web3": "^1.0.0-beta.34"
           }
         },
         "web3": {
@@ -6840,6 +6788,12 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@nomiclabs/buidler": "1.3.0",
     "@nomiclabs/buidler-truffle5": "1.3.0",
     "@nomiclabs/buidler-web3": "1.3.0",
-    "@openzeppelin/test-helpers": "0.5.5",
+    "@openzeppelin/test-helpers": "0.5.6",
     "chai": "4.2.0",
     "chai-bn": "0.2.0",
     "mv": "2.1.1",

--- a/test/sol6/emergencyFeeHandler.js
+++ b/test/sol6/emergencyFeeHandler.js
@@ -1,0 +1,370 @@
+const EmergencyKyberFeeHandler = artifacts.require('EmergencyKyberFeeHandler.sol')
+const MockEmergencyFeeHandler = artifacts.require('MockEmergencyFeeHandler.sol')
+const KyberNetwork = artifacts.require('KyberNetwork.sol')
+const KyberStorage = artifacts.require('KyberStorage.sol')
+const MatchingEngine = artifacts.require('KyberMatchingEngine.sol')
+const TestToken = artifacts.require('Token.sol')
+
+const Helper = require('../helper.js')
+const nwHelper = require('./networkHelper.js')
+const BN = web3.utils.BN
+const {
+  BPS,
+  precisionUnits,
+  ethDecimals,
+  ethAddress,
+  zeroAddress,
+  emptyHint,
+  zeroBN,
+  MAX_QTY,
+  MAX_RATE
+} = require('../helper.js')
+const {expectEvent, expectRevert} = require('@openzeppelin/test-helpers')
+
+let admin
+let feeHandler
+let network
+let rebateBpsPerWallet
+let rebateWallets
+let platformWallet
+let user
+
+let rewardBps = new BN(5000)
+let rebateBps = new BN(2500)
+let burnBps = new BN(2500)
+
+contract('EmergencyKyberFeeHandler', function (accounts) {
+  before('Setting global variables', async () => {
+    admin = accounts[1]
+    network = accounts[2]
+    rebateBpsPerWallet = [new BN(4000), new BN(6000)]
+    rebateWallets = [accounts[3], accounts[4]]
+    platformWallet = accounts[5]
+    user = accounts[6]
+  })
+
+  describe('valid constructor params', async () => {
+    it('test total BRR value should be BPS', async () => {
+      await expectRevert(
+        EmergencyKyberFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps.add(new BN(1))),
+        'Bad BRR values'
+      )
+    })
+
+    it('test total BRR value should not be overflow', async () => {
+      await expectRevert.unspecified(
+        EmergencyKyberFeeHandler.new(admin, network, new BN(BPS), new BN(1), new BN(2).pow(new BN(256)).sub(new BN(1)))
+      )
+    })
+  })
+
+  describe('test set network', async () => {
+    let newNetwork = accounts[3]
+    before('init emergencyFeeHandler', async () => {
+      feeHandler = await EmergencyKyberFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps)
+    })
+
+    it('should revert if not amin set network', async () => {
+      await expectRevert(feeHandler.setNetworkContract(newNetwork, {from: user}), 'only admin')
+    })
+
+    it('should revert if new network is zero', async () => {
+      await expectRevert(feeHandler.setNetworkContract(zeroAddress, {from: admin}), 'kyberNetwork 0')
+    })
+
+    it('should success and emit events', async () => {
+      let txResult = await feeHandler.setNetworkContract(newNetwork, {from: admin})
+      await expectEvent(txResult, 'KyberNetworkUpdated', {kyberNetwork: newNetwork})
+    })
+  })
+
+  describe('test handle fees with mock Network', async () => {
+    before('init emergencyFeeHandler', async () => {
+      feeHandler = await EmergencyKyberFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps)
+    })
+
+    it('should handle Fee', async () => {
+      let platformFeeWei = new BN(10).pow(new BN(17))
+      let fee = new BN(10).pow(new BN(18))
+
+      let initalState = await getFeeHanlerState(feeHandler, rebateWallets, platformWallet)
+      let txResult = await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet, platformWallet, platformFeeWei, {
+        from: network,
+        value: fee
+      })
+
+      let feeBrrWei = fee.sub(platformFeeWei)
+      let rewardWei = feeBrrWei.mul(rewardBps).div(BPS)
+
+      await expectEvent(txResult, 'HandleFee', {
+        platformWallet,
+        platformFeeWei,
+        feeBRRWei: feeBrrWei
+      })
+
+      await expectEvent(txResult, 'BRRFeeDistribution', {
+        rewardWei: rewardWei
+      })
+
+      await assertStateAfterHandlerFees(
+        feeHandler,
+        initalState,
+        rebateWallets,
+        rebateBpsPerWallet,
+        platformWallet,
+        platformFeeWei,
+        fee
+      )
+    })
+
+    it('should handle Fee with only platform Fee', async () => {
+      let platformFeeWei = new BN(10).pow(new BN(17))
+      let initalState = await getFeeHanlerState(feeHandler, rebateWallets, platformWallet)
+      let txResult = await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet, platformWallet, platformFeeWei, {
+        from: network,
+        value: platformFeeWei
+      })
+
+      await expectEvent(txResult, 'HandleFee', {
+        platformWallet,
+        platformFeeWei,
+        feeBRRWei: new BN(0),
+      })
+      await assertStateAfterHandlerFees(
+        feeHandler,
+        initalState,
+        rebateWallets,
+        rebateBpsPerWallet,
+        platformWallet,
+        platformFeeWei,
+        platformFeeWei
+      )
+    })
+
+    it('test failtolerance when calculateAndRecordFeeData failed', async () => {
+      feeHandler = await MockEmergencyFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps)
+      let platformFeeWei = new BN(10).pow(new BN(17))
+      let fee = new BN(10).pow(new BN(18))
+
+      let initalFeePerPlatformWallet = await feeHandler.feePerPlatformWallet(platformWallet)
+      let txResult = await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet, platformWallet, platformFeeWei, {
+        from: network,
+        value: fee
+      })
+
+      await expectEvent(txResult, 'HandleFeeFailed', {
+        feeBRRWei: fee.sub(platformFeeWei)
+      })
+      //platform fee should update as normal
+      let afterFeePerPlatformWallet = await feeHandler.feePerPlatformWallet(platformWallet)
+      Helper.assertEqual(
+        initalFeePerPlatformWallet.add(platformFeeWei),
+        afterFeePerPlatformWallet,
+        'unexpected feePerPlatformWallet'
+      )
+    })
+  })
+
+  describe('test withdraw and claimPlatformFee function', async () => {
+    let availableFee
+    let totalBalance
+    let platformFeeWei
+    before('create new feehandler', async () => {
+      feeHandler = await EmergencyKyberFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps)
+      platformFeeWei = new BN(10).pow(new BN(17))
+      totalBalance = new BN(10).pow(new BN(18))
+      await feeHandler.handleFees(rebateWallets, rebateBpsPerWallet, platformWallet, platformFeeWei, {
+        from: network,
+        value: totalBalance
+      })
+      availableFee = totalBalance.sub(platformFeeWei)
+    })
+
+    it('test withdraw revert if not admin', async () => {
+      await expectRevert(feeHandler.withdraw(user, availableFee, {from: network}), 'only admin')
+    })
+
+    it('test withdraw revert if not admin', async () => {
+      await expectRevert(feeHandler.withdraw(user, totalBalance, {from: admin}), 'amount > available funds')
+    })
+
+    it('test withdraw success', async () => {
+      let initialBalance = await Helper.getBalancePromise(user)
+      let txResult = await feeHandler.withdraw(user, availableFee, {from: admin})
+      expectEvent(txResult, 'EtherWithdraw', {
+        amount: availableFee,
+        sendTo: user
+      })
+      Helper.assertEqual(initialBalance.add(availableFee), await Helper.getBalancePromise(user))
+    })
+
+    it('test claimPlatformFee success', async () => {
+      let initialBalance = await Helper.getBalancePromise(platformWallet)
+      let initialTotalPlatformFee = await feeHandler.totalPlatformFeeWei()
+      let txResult = await feeHandler.claimPlatformFee(platformWallet)
+      expectEvent(txResult, 'PlatformFeePaid', {
+        platformWallet: platformWallet,
+        amountWei: platformFeeWei.sub(new BN(1))
+      })
+      let afterBalance = await Helper.getBalancePromise(platformWallet)
+      Helper.assertEqual(initialBalance.add(platformFeeWei).sub(new BN(1)), afterBalance, 'unexpected balance')
+      let afterTotalPlatformFee = await feeHandler.totalPlatformFeeWei()
+      Helper.assertEqual(
+        initialTotalPlatformFee.sub(platformFeeWei.sub(new BN(1))),
+        afterTotalPlatformFee,
+        'total balance platform fee wei is not update as expected'
+      )
+    })
+  })
+
+  it('should revert with not implemented method from IKyberFeeHandler', async () => {
+    feeHandler = await EmergencyKyberFeeHandler.new(admin, network, rewardBps, rebateBps, burnBps)
+    await expectRevert(feeHandler.claimReserveRebate(rebateWallets[0]), 'not implemented')
+    await expectRevert(feeHandler.claimStakerReward(rebateWallets[0], new BN(0), new BN(0)), 'not implemented')
+  })
+
+  describe('test integration with real network', async () => {
+    // network related variables
+    let networkProxy
+    let operator
+    let alerter
+    let taker
+    let kyberNetwork
+    let storage
+    let reserveIdToWallet
+
+    const gasPrice = new BN(10).pow(new BN(9)).mul(new BN(50))
+    const negligibleRateDiffBps = new BN(10) //0.01%
+    const maxDestAmt = new BN(2).pow(new BN(255))
+    const minConversionRate = new BN(0)
+
+    let testToken
+    let platformFeeBps = new BN(20) // 0.2%
+    let networkFeeBps = new BN(25) // default fee when daoAddress is zero
+
+    before('init network, ...', async () => {
+      networkProxy = accounts[6]
+      operator = accounts[7]
+      alerter = accounts[8]
+      taker = accounts[9]
+
+      // init storage and network
+      storage = await nwHelper.setupStorage(admin)
+      kyberNetwork = await KyberNetwork.new(admin, storage.address)
+      await storage.setNetworkContract(kyberNetwork.address, {from: admin})
+      await storage.addOperator(operator, {from: admin})
+
+      feeHandler = await EmergencyKyberFeeHandler.new(admin, kyberNetwork.address, rewardBps, rebateBps, burnBps)
+      // init matchingEngine
+      matchingEngine = await MatchingEngine.new(admin)
+      await matchingEngine.setNetworkContract(kyberNetwork.address, {from: admin})
+      await matchingEngine.setKyberStorage(storage.address, {from: admin})
+      await storage.setFeeAccountedPerReserveType(true, true, true, true, true, true, {
+        from: admin
+      })
+      await storage.setEntitledRebatePerReserveType(true, true, true, true, true, true, {
+        from: admin
+      })
+
+      // setup network
+      await kyberNetwork.setContracts(feeHandler.address, matchingEngine.address, zeroAddress, {
+        from: admin
+      })
+      await kyberNetwork.addOperator(operator, {from: admin})
+      await kyberNetwork.addKyberProxy(networkProxy, {from: admin})
+      // in the emergency case, dao address is set to zero
+      await kyberNetwork.setKyberDaoContract(zeroAddress, {from: admin})
+      //set params, enable network
+      await kyberNetwork.setParams(gasPrice, negligibleRateDiffBps, {from: admin})
+      await kyberNetwork.setEnable(true, {from: admin})
+
+      testToken = await TestToken.new('test', 'tst', new BN(18))
+      let tokens = [testToken]
+      rebateWallets = [accounts[7], accounts[8]]
+      let result = await nwHelper.setupReserves(network, tokens, 2, 0, 0, 0, accounts, admin, operator, rebateWallets)
+      reserveIdToWallet = result.reserveIdToRebateWallet
+      await nwHelper.addReservesToStorage(storage, result.reserveInstances, tokens, operator)
+    })
+
+    it('network should trade, fee update as expected', async () => {
+      let ethSrcQty = new BN(10).pow(new BN(18))
+      let initalState = await getFeeHanlerState(feeHandler, rebateWallets, platformWallet)
+      let txResult = await kyberNetwork.tradeWithHintAndFee(
+        kyberNetwork.address,
+        ethAddress,
+        ethSrcQty,
+        testToken.address,
+        taker,
+        maxDestAmt,
+        minConversionRate,
+        platformWallet,
+        platformFeeBps,
+        emptyHint,
+        {value: ethSrcQty, from: networkProxy}
+      )
+
+      let tradeEventArgs = nwHelper.getTradeEventArgs(txResult)
+      let tradedReserve = tradeEventArgs.e2tIds[0]
+      let rebateWallet = reserveIdToWallet[tradedReserve]
+      platformFeeWei = ethSrcQty.mul(platformFeeBps).div(BPS)
+      fee = ethSrcQty
+        .mul(networkFeeBps)
+        .div(BPS)
+        .add(platformFeeWei)
+      await assertStateAfterHandlerFees(
+        feeHandler,
+        initalState,
+        [rebateWallet],
+        [BPS],
+        platformWallet,
+        platformFeeWei,
+        fee
+      )
+    })
+  })
+})
+
+async function getFeeHanlerState (feeHandler, rebateWallets, platformWallet) {
+  let rebatePerWallet = []
+  for (let i = 0; i < rebateWallets.length; i++) {
+    let rebateWei = await feeHandler.rebatePerWallet(rebateWallets[i])
+    rebatePerWallet.push(rebateWei)
+  }
+  return {
+    rewardWei: await feeHandler.totalRewardWei(),
+    platformFeeWei: await feeHandler.feePerPlatformWallet(platformWallet),
+    rebatePerWallet
+  }
+}
+
+async function assertStateAfterHandlerFees (
+  feeHandler,
+  initalState,
+  rebateWallets,
+  rebateBpsPerWallet,
+  platformWallet,
+  platformFeeWei,
+  fee
+) {
+  let afterState = await getFeeHanlerState(feeHandler, rebateWallets, platformWallet)
+  let expectedPlatformFeeWei = initalState.platformFeeWei.add(platformFeeWei)
+  Helper.assertEqual(expectedPlatformFeeWei, afterState.platformFeeWei, 'unexpected platform Fee')
+
+  let feeBrrWei = fee.sub(platformFeeWei)
+  let rewardWei = feeBrrWei.mul(rewardBps).div(BPS)
+  Helper.assertEqual(afterState.rewardWei, initalState.rewardWei.add(rewardWei), 'unexpected rewardWei')
+
+  if (rebateWallets.length == 0) {
+    return
+  }
+  let rebateWei = feeBrrWei.mul(rebateBps).div(BPS)
+
+  for (let i = 0; i < rebateWallets.length; i++) {
+    let rebatePerWallet = rebateWei.mul(rebateBpsPerWallet[i]).div(BPS)
+    Helper.assertEqual(
+      rebatePerWallet.add(initalState.rebatePerWallet[i]),
+      afterState.rebatePerWallet[i],
+      'unpected rebatePerWallet'
+    )
+  }
+}


### PR DESCRIPTION
This PR create an emergency fee handler handling the fee when FeeHandler is unavailable (bug,..)
- Keep track of platformFee and allow to claimPlatformFee
- Keep track of rebatePerWallet and totalRewardWei, but not allow to claim rebate fee and reward
- Admin can withdraw to distribute the reward and fee but no more than totalBalance - totalPlatformFee