### PR TITLE
Auto delist tokens when removing reserve

### DIFF
--- a/contracts/sol6/KyberStorage.sol
+++ b/contracts/sol6/KyberStorage.sol
@@ -30,6 +30,8 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
     mapping(address => bytes32) internal reserveAddressToId;
     mapping(address => bytes32[]) internal reservesPerTokenSrc; // reserves supporting token to eth
     mapping(address => bytes32[]) internal reservesPerTokenDest; // reserves support eth to token
+    mapping(bytes32 => IERC20[]) internal srcTokensPerReserve;
+    mapping(bytes32 => IERC20[]) internal destTokensPerReserve;
 
     uint256 internal feeAccountedPerType = 0xffffffff;
     uint256 internal entitledRebatePerType = 0xffffffff;
@@ -167,6 +169,9 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
         require(reserveIdToAddresses[reserveId].length > 0, "reserveId not found");
         address reserve = reserveIdToAddresses[reserveId][0];
 
+        // delist all token pairs for reserve
+        delistTokensOfReserve(reserveId);
+
         uint256 reserveIndex = 2**255;
         for (uint256 i = startIndex; i < reserves.length; i++) {
             if (reserves[i] == IKyberReserve(reserve)) {
@@ -206,7 +211,7 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
         bool ethToToken,
         bool tokenToEth,
         bool add
-    ) external {
+    ) public {
         onlyOperator();
 
         require(reserveIdToAddresses[reserveId].length > 0, "reserveId not found");
@@ -501,6 +506,32 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
         isEntitledRebateFlag = (entitledRebatePerType & (1 << resTypeUint)) > 0;
     }
 
+    function getListedTokensByReserveId(bytes32 reserveId)
+        external
+        view
+        returns (
+            IERC20[] memory srcTokens,
+            IERC20[] memory destTokens
+        )
+    {
+        srcTokens = srcTokensPerReserve[reserveId];
+        destTokens = destTokensPerReserve[reserveId];
+    }
+
+    function getListedTokensByReserveAddress(address reserve)
+        external
+        view
+        returns (
+            IERC20[] memory srcTokens,
+            IERC20[] memory destTokens
+        )
+    {
+        bytes32 reserveId = reserveAddressToId[reserve];
+        srcTokens = srcTokensPerReserve[reserveId];
+        destTokens = destTokensPerReserve[reserveId];
+    }
+
+
     function getFeeAccountedData(bytes32[] calldata reserveIds)
         external
         view
@@ -555,6 +586,21 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
         }
     }
 
+    function delistTokensOfReserve(bytes32 reserveId) internal {
+        // token to ether
+        // memory declaration instead of storage because we are modifying the storage array
+        IERC20[] memory tokensArr = srcTokensPerReserve[reserveId];
+        for (uint256 i = 0; i < tokensArr.length; i++) {
+            listPairForReserve(reserveId, tokensArr[i], false, true, false);
+        }
+
+        // ether to token
+        tokensArr = destTokensPerReserve[reserveId];
+        for (uint256 i = 0; i < tokensArr.length; i++) {
+            listPairForReserve(reserveId, tokensArr[i], true, false, false);
+        }
+    }
+
     function listPairs(
         bytes32 reserveId,
         IERC20 token,
@@ -563,17 +609,19 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
     ) internal {
         uint256 i;
         bytes32[] storage reserveArr = reservesPerTokenDest[address(token)];
+        IERC20[] storage tokensArr = destTokensPerReserve[reserveId];
 
         if (isTokenToEth) {
             reserveArr = reservesPerTokenSrc[address(token)];
+            tokensArr = srcTokensPerReserve[reserveId];
         }
 
         for (i = 0; i < reserveArr.length; i++) {
             if (reserveId == reserveArr[i]) {
                 if (add) {
-                    break; // already added
+                    return; // reserve already added, no further action needed
                 } else {
-                    // remove
+                    // remove reserve from reserveArr
                     reserveArr[i] = reserveArr[reserveArr.length - 1];
                     reserveArr.pop();
                     break;
@@ -581,9 +629,19 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
             }
         }
 
-        if (add && i == reserveArr.length) {
-            // if reserve wasn't found add it
+        if (add) {
+            // add reserve and token to reserveArr and tokensArr respectively
             reserveArr.push(reserveId);
+            tokensArr.push(token);
+        } else {
+            // remove token from tokenArr
+            for (i = 0; i < tokensArr.length; i++) {
+                if (token == tokensArr[i]) {
+                    tokensArr[i] = tokensArr[tokensArr.length - 1];
+                    tokensArr.pop();
+                    break;
+                }
+            }
         }
     }
 

--- a/contracts/sol6/KyberStorage.sol
+++ b/contracts/sol6/KyberStorage.sol
@@ -518,20 +518,6 @@ contract KyberStorage is IKyberStorage, PermissionGroupsNoModifiers, Utils5 {
         destTokens = destTokensPerReserve[reserveId];
     }
 
-    function getListedTokensByReserveAddress(address reserve)
-        external
-        view
-        returns (
-            IERC20[] memory srcTokens,
-            IERC20[] memory destTokens
-        )
-    {
-        bytes32 reserveId = reserveAddressToId[reserve];
-        srcTokens = srcTokensPerReserve[reserveId];
-        destTokens = destTokensPerReserve[reserveId];
-    }
-
-
     function getFeeAccountedData(bytes32[] calldata reserveIds)
         external
         view

--- a/test/sol6/kyberStorage.js
+++ b/test/sol6/kyberStorage.js
@@ -502,7 +502,25 @@ contract('KyberStorage', function(accounts) {
                 Helper.assertEqual(reserveData.resType, "0", "reserve type not 0");
                 Helper.assertEqual(reserveData.isFeeAccountedFlag, false, "isFeeAccountedFlag not false");
                 Helper.assertEqual(reserveData.isEntitledRebateFlag, false, "isEntitledRebateFlag not false");
-            })
+
+                let result = await kyberStorage.getListedTokensByReserveId(reserveId);
+                Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens not empty");
+                Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens not empty");
+            });
+
+            it("should return no reserve data if reserve address does not exist", async() => {
+                let reserveData = await kyberStorage.getReserveDetailsByAddress(admin);
+    
+                Helper.assertEqual(reserveData.reserveId, nwHelper.ZERO_RESERVE_ID, "reserve ID not 0x0");
+                Helper.assertEqual(reserveData.rebateWallet, "0x0000000000000000000000000000000000000000", "rebate wallet not 0x0");
+                Helper.assertEqual(reserveData.resType, "0", "reserve type not 0");
+                Helper.assertEqual(reserveData.isFeeAccountedFlag, false, "isFeeAccountedFlag not false");
+                Helper.assertEqual(reserveData.isEntitledRebateFlag, false, "isEntitledRebateFlag not false");
+
+                let result = await kyberStorage.getListedTokensByReserveAddress(admin);
+                Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens not empty");
+                Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens not empty");
+            });
         });
 
         describe("test cases for an already added reserve", async() => {
@@ -845,6 +863,16 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqualArray(result, reserveIds, "E2T should be listed");
+
+            for (let reserve of Object.values(reserveInstances)) {
+                result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+                Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+                Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
+                result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+                Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+                Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
+            };
+
             // delist for both side
             for (let reserve of Object.values(reserveInstances)) {
                 await kyberStorage.listPairForReserve(reserve.reserveId, token.address, true, true, false, {from: operator});
@@ -860,6 +888,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
 
         it("should list T2E side only", async() => {
@@ -871,6 +906,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
 
         it("should list both T2E and E2T", async() => {
@@ -882,6 +924,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
 
         it("should delist T2E side only", async() => {
@@ -894,6 +943,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
 
         it("should delist E2T side only", async() => {
@@ -906,6 +962,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
 
         it("should delist both T2E and E2T", async() => {
@@ -918,6 +981,13 @@ contract('KyberStorage', function(accounts) {
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
             Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
 
         it("should revert for listing twice (approving)", async() => {
@@ -926,12 +996,12 @@ contract('KyberStorage', function(accounts) {
                 kyberStorage.listPairForReserve(reserve.reserveId, token.address, true, true, true, {from: operator})
             )
             let result = await kyberStorage.getReserveIdsPerTokenSrc(token.address);
-            Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
+            Helper.assertEqual(result[0], reserve.reserveId, "T2E should be listed");
             result = await kyberStorage.getReserveAddressesPerTokenSrc(token.address, 0, 0);
-            Helper.assertEqual(result[0], reserve.address, "E2T should be listed");
+            Helper.assertEqual(result[0], reserve.address, "T2E should be listed");
 
             result = await kyberStorage.getReserveIdsPerTokenDest(token.address);
-            Helper.assertEqual(result[0], reserve.reserveId, "T2E should be listed");
+            Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
         });
 
         it("should revert when list tokens for reserve that has been removed", async() => {
@@ -944,6 +1014,52 @@ contract('KyberStorage', function(accounts) {
                 kyberStorage.listPairForReserve(mockReserveId, token.address, true, true, true, {from: operator}),
                 "reserve = 0"
            );
+        });
+
+        it("should delist all tokens automatically when only removeReserve is called", async() => {
+            let token2 = await TestToken.new("test2", "tst2", 18);
+            let token3 = await TestToken.new("test3", "tst3", 18);
+            // 1 token for only T2E, 1 token for both side, 1 token for only E2T
+            let srcTokenAddresses = [token.address, token2.address];
+            let destTokenAddresses = [token2.address, token3.address];
+            let allTokenAddresses = [token.address, token2.address, token3.address];
+            let result;
+
+            await kyberStorage.listPairForReserve(reserve.reserveId, token.address, false, true, true, {from: operator});
+            await kyberStorage.listPairForReserve(reserve.reserveId, token2.address, true, true, true, {from: operator});
+            await kyberStorage.listPairForReserve(reserve.reserveId, token3.address, true, false, true, {from: operator});
+
+            for (let tokenAdd of Object.values(srcTokenAddresses)) {
+                result = await kyberStorage.getReserveIdsPerTokenSrc(tokenAdd);
+                Helper.assertEqual(result[0], reserve.reserveId, "T2E should be listed");
+            }
+
+            for (let tokenAdd of Object.values(destTokenAddresses)) {
+                result = await kyberStorage.getReserveIdsPerTokenDest(tokenAdd);
+                Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
+            }
+
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqualArray(result.srcTokens, srcTokenAddresses, "src tokens listed not the same");
+            Helper.assertEqualArray(result.destTokens, destTokenAddresses, "dest tokens listed not the same");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqualArray(result.srcTokens, srcTokenAddresses, "src tokens listed not the same");
+            Helper.assertEqualArray(result.destTokens, destTokenAddresses, "dest tokens listed not the same");
+
+            await kyberStorage.removeReserve(reserve.reserveId, 0, {from: operator});
+
+            for (let tokenAdd of Object.values(allTokenAddresses)) {
+                result = await kyberStorage.getReserveIdsPerTokenSrc(tokenAdd);
+                Helper.assertEqual(result.length, zeroBN, "T2E should not be listed");
+                result = await kyberStorage.getReserveIdsPerTokenDest(tokenAdd);
+                Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
+            }
+            result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens listed not the same");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens listed not the same");
+            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
+            Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens listed not the same");
+            Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens listed not the same");
         });
     });
 

--- a/test/sol6/kyberStorage.js
+++ b/test/sol6/kyberStorage.js
@@ -516,10 +516,6 @@ contract('KyberStorage', function(accounts) {
                 Helper.assertEqual(reserveData.resType, "0", "reserve type not 0");
                 Helper.assertEqual(reserveData.isFeeAccountedFlag, false, "isFeeAccountedFlag not false");
                 Helper.assertEqual(reserveData.isEntitledRebateFlag, false, "isEntitledRebateFlag not false");
-
-                let result = await kyberStorage.getListedTokensByReserveAddress(admin);
-                Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens not empty");
-                Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens not empty");
             });
         });
 
@@ -868,9 +864,6 @@ contract('KyberStorage', function(accounts) {
                 result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
                 Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
                 Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
-                result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-                Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
-                Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
             };
 
             // delist for both side
@@ -892,9 +885,6 @@ contract('KyberStorage', function(accounts) {
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
             Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
             Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
-            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
 
         it("should list T2E side only", async() => {
@@ -910,9 +900,6 @@ contract('KyberStorage', function(accounts) {
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
             Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
             Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
-            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
 
         it("should list both T2E and E2T", async() => {
@@ -926,9 +913,6 @@ contract('KyberStorage', function(accounts) {
             Helper.assertEqual(result[0], reserve.reserveId, "E2T should be listed");
 
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
-            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
-            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
             Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
             Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
@@ -947,9 +931,6 @@ contract('KyberStorage', function(accounts) {
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
             Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
             Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
-            Helper.assertEqual(result.destTokens[0], token.address, "E2T should be listed");
         });
 
         it("should delist E2T side only", async() => {
@@ -966,9 +947,6 @@ contract('KyberStorage', function(accounts) {
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
             Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
             Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-            Helper.assertEqual(result.srcTokens[0], token.address, "T2E should be listed");
-            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
 
         it("should delist both T2E and E2T", async() => {
@@ -983,9 +961,6 @@ contract('KyberStorage', function(accounts) {
             Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
 
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
-            Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
-            Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
             Helper.assertEqual(result.srcTokens.length, zeroBN, "T2E should not be listed");
             Helper.assertEqual(result.destTokens.length, zeroBN, "E2T should not be listed");
         });
@@ -1042,9 +1017,6 @@ contract('KyberStorage', function(accounts) {
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
             Helper.assertEqualArray(result.srcTokens, srcTokenAddresses, "src tokens listed not the same");
             Helper.assertEqualArray(result.destTokens, destTokenAddresses, "dest tokens listed not the same");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
-            Helper.assertEqualArray(result.srcTokens, srcTokenAddresses, "src tokens listed not the same");
-            Helper.assertEqualArray(result.destTokens, destTokenAddresses, "dest tokens listed not the same");
 
             await kyberStorage.removeReserve(reserve.reserveId, 0, {from: operator});
 
@@ -1055,9 +1027,6 @@ contract('KyberStorage', function(accounts) {
                 Helper.assertEqual(result.length, zeroBN, "E2T should not be listed");
             }
             result = await kyberStorage.getListedTokensByReserveId(reserve.reserveId);
-            Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens listed not the same");
-            Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens listed not the same");
-            result = await kyberStorage.getListedTokensByReserveAddress(reserve.address);
             Helper.assertEqual(result.srcTokens.length, zeroBN, "src tokens listed not the same");
             Helper.assertEqual(result.destTokens.length, zeroBN, "dest tokens listed not the same");
         });


### PR DESCRIPTION
- Mappings `srcTokensPerReserve` and `destTokensPerReserve`
- `getListedTokensByReserveId()` and `getListedTokensByReserveAddress()`
- `delistTokensOfReserve` to automatically delist all tokens when removing reserve