### PR TITLE
storage validate if reserve is listed for token

### DIFF
--- a/contracts/sol6/IKyberStorage.sol
+++ b/contracts/sol6/IKyberStorage.sol
@@ -10,7 +10,6 @@ interface IKyberStorage {
     function addKyberProxy(address networkProxy, uint256 maxApprovedProxies)
         external;
 
-
     function removeKyberProxy(address networkProxy) external;
 
     function setContracts(address _feeHandler, address _matchingEngine) external;
@@ -88,10 +87,11 @@ interface IKyberStorage {
         view
         returns (bool[] memory entitledRebateArr);
 
-    function getReservesData(bytes32[] calldata reserveIds)
+    function getReservesData(bytes32[] calldata reserveIds, IERC20 src, IERC20 dest)
         external
         view
         returns (
+            bool areAllReservesListed,
             bool[] memory feeAccountedArr,
             bool[] memory entitledRebateArr,
             IKyberReserve[] memory reserveAddresses);

--- a/contracts/sol6/KyberNetwork.sol
+++ b/contracts/sol6/KyberNetwork.sol
@@ -665,7 +665,7 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
         uint256 rateWithNetworkFee;
         (destAmount, rateWithNetworkFee) = calcRatesAndAmounts(tradeData, hint);
 
-        require(rateWithNetworkFee > 0, "0 rate");
+        require(rateWithNetworkFee > 0, "trade invalid, if hint involved, try parseHint API");
         require(rateWithNetworkFee < MAX_RATE, "rate > MAX_RATE");
         require(rateWithNetworkFee >= tradeData.input.minConversionRate, "rate < min rate");
 
@@ -874,8 +874,13 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
             (tradeData.input.src != ETH_TOKEN_ADDRESS) && (tradeData.input.dest != ETH_TOKEN_ADDRESS),
             hint
         );
-        (reservesData.isFeeAccountedFlags, reservesData.isEntitledRebateFlags, reservesData.addresses)
-            = kyberStorage.getReservesData(reservesData.ids);
+        bool areAllReservesListed;
+        (areAllReservesListed, reservesData.isFeeAccountedFlags, reservesData.isEntitledRebateFlags, reservesData.addresses)
+            = kyberStorage.getReservesData(reservesData.ids, src, dest);
+
+        if(!areAllReservesListed) {
+            return 0;
+        }
 
         require(reservesData.ids.length == reservesData.splitsBps.length, "bad split array");
         require(reservesData.ids.length == reservesData.isFeeAccountedFlags.length, "bad fee array");

--- a/contracts/sol6/mock/GenerousKyberNetwork.sol
+++ b/contracts/sol6/mock/GenerousKyberNetwork.sol
@@ -34,7 +34,7 @@ contract GenerousKyberNetwork is KyberNetwork {
         uint256 rateWithNetworkFee;
         (destAmount, rateWithNetworkFee) = calcRatesAndAmounts(tData, hint);
 
-        require(rateWithNetworkFee > 0, "0 rate");
+        require(rateWithNetworkFee > 0, "trade invalid, if hint involved, try parseHint API");
         require(rateWithNetworkFee < MAX_RATE, "rate > MAX_RATE");
         require(rateWithNetworkFee >= tData.input.minConversionRate, "rate < minConvRate");
 

--- a/contracts/sol6/mock/GenerousKyberNetwork.sol
+++ b/contracts/sol6/mock/GenerousKyberNetwork.sol
@@ -28,7 +28,7 @@ contract GenerousKyberNetwork is KyberNetwork {
         tData.networkFeeBps = getAndUpdateNetworkFee();
 
         // destAmount = printGas("start_tr", 0, Module.NETWORK);
-        verifyTradeInputValid(tData.input, tData.networkFeeBps);
+        validateTradeInput(tData.input);
 
         // amounts excluding fees
         uint256 rateWithNetworkFee;

--- a/contracts/sol6/mock/GenerousKyberNetwork2.sol
+++ b/contracts/sol6/mock/GenerousKyberNetwork2.sol
@@ -23,7 +23,7 @@ contract GenerousKyberNetwork2 is KyberNetwork {
     {
         tData.networkFeeBps = getAndUpdateNetworkFee();
 
-        verifyTradeInputValid(tData.input, tData.networkFeeBps);
+        validateTradeInput(tData.input);
 
         // amounts excluding fees
         uint256 rateWithNetworkFee;

--- a/contracts/sol6/mock/GenerousKyberNetwork2.sol
+++ b/contracts/sol6/mock/GenerousKyberNetwork2.sol
@@ -29,7 +29,7 @@ contract GenerousKyberNetwork2 is KyberNetwork {
         uint256 rateWithNetworkFee;
         (destAmount, rateWithNetworkFee) = calcRatesAndAmounts(tData, hint);
 
-        require(rateWithNetworkFee > 0, "0 rate");
+        require(rateWithNetworkFee > 0, "trade invalid, if hint involved, try parseHint API");
         require(rateWithNetworkFee < MAX_RATE, "rate > MAX_RATE");
         require(rateWithNetworkFee >= tData.input.minConversionRate, "rate < min Rate");
 

--- a/contracts/sol6/mock/MaliciousKyberNetwork.sol
+++ b/contracts/sol6/mock/MaliciousKyberNetwork.sol
@@ -26,7 +26,7 @@ contract MaliciousKyberNetwork is KyberNetwork {
     {
         tData.networkFeeBps = getAndUpdateNetworkFee();
 
-        verifyTradeInputValid(tData.input, tData.networkFeeBps);
+        validateTradeInput(tData.input);
 
         // amounts excluding fees
         uint256 rateWithNetworkFee;

--- a/contracts/sol6/mock/MaliciousKyberNetwork.sol
+++ b/contracts/sol6/mock/MaliciousKyberNetwork.sol
@@ -32,7 +32,7 @@ contract MaliciousKyberNetwork is KyberNetwork {
         uint256 rateWithNetworkFee;
         (destAmount, rateWithNetworkFee) = calcRatesAndAmounts(tData, hint);
 
-        require(rateWithNetworkFee > 0, "0 rate");
+        require(rateWithNetworkFee > 0, "trade invalid, if hint involved, try parseHint API");
         require(rateWithNetworkFee < MAX_RATE, "rate > MAX_RATE");
         require(rateWithNetworkFee >= tData.input.minConversionRate, "rate < minConvRate");
 

--- a/contracts/sol6/mock/MaliciousStorage.sol
+++ b/contracts/sol6/mock/MaliciousStorage.sol
@@ -37,15 +37,17 @@ contract MaliciousStorage {
         networkProxy;
     }
 
-    function getReservesData(bytes32[] calldata reserveIds)
+    function getReservesData(bytes32[] calldata reserveIds, IERC20 , IERC20 )
         external
         view
         returns (
+            bool isValid,
             bool[] memory feeAccountedArr,
             bool[] memory entitledRebateArr,
             IKyberReserve[] memory reserveAddresses
             )
     {
+        isValid = true;
         reserveIds;
         feeAccountedArr = new bool[](feeArrayLength);
         entitledRebateArr = new bool[](entitledRebateLength);

--- a/test/sol4/kyberProxyV1.js
+++ b/test/sol4/kyberProxyV1.js
@@ -526,7 +526,7 @@ contract('KyberProxyV1', function(accounts) {
                         hint,
                         {from: taker, value: ethSrcQty},
                     ),
-                    "0 rate"
+                    "trade invalid, if hint involved, try parseHint API"
                 );
 
                 // T2E trade
@@ -542,7 +542,7 @@ contract('KyberProxyV1', function(accounts) {
                         hint,
                         {from: taker}
                     ),
-                    "0 rate"
+                    "trade invalid, if hint involved, try parseHint API"
                 );
 
                 // T2T trade
@@ -558,7 +558,7 @@ contract('KyberProxyV1', function(accounts) {
                         hint,
                         {from: taker},
                     ),
-                    "0 rate"
+                    "trade invalid, if hint involved, try parseHint API"
                 );
                 hint = web3.utils.fromAscii("PERM");
             });

--- a/test/sol6/kyberNetwork.js
+++ b/test/sol6/kyberNetwork.js
@@ -2833,8 +2833,8 @@ contract('KyberNetwork', function(accounts) {
         it("test can not trade when platform fee is too high", async () => {
             let invalidPlatformFee = new BN(10001); // 10001 BPS = 100.01%
             await expectRevert(
-                network.tradeWithHintAndFee(networkProxy, srcToken.address, srcQty, ethAddress, taker,
-                    maxDestAmt, minConversionRate, platformWallet, invalidPlatformFee, emptyHint),
+                network.tradeWithHintAndFee(networkProxy, ethAddress, srcQty, srcToken.address, taker,
+                    maxDestAmt, minConversionRate, platformWallet, invalidPlatformFee, emptyHint, {value : srcQty}),
                 "platformFee high"
             );
         });
@@ -2847,8 +2847,8 @@ contract('KyberNetwork', function(accounts) {
             // expect invalidPlatformFee + networkFee*2 > BPS
 
             await expectRevert(
-                network.tradeWithHintAndFee(networkProxy, srcToken.address, srcQty, ethAddress, taker,
-                    maxDestAmt, minConversionRate, platformWallet, invalidPlatformFee, emptyHint),
+                network.tradeWithHintAndFee(networkProxy, ethAddress, srcQty, srcToken.address, taker,
+                    maxDestAmt, minConversionRate, platformWallet, invalidPlatformFee, emptyHint, {value: srcQty}),
                 "fees high"
             );
         });


### PR DESCRIPTION
What did this PR do:
- validate if reserve is listed for token (for maskIn, Split trades)
- better revert msg if network return 0 rate
- network validate input when getExpectedRate
Checklist:
- [x] Network byte code size: 24533
- [x] Write uint tests for storage
- [x] Write uint tests for trade with unlisted reserve at network
- [ ] Change buildHint function of MatchingEngine

Gas report

```
┌─────────────────────────────────────────────────────────┬──────────┬─────────┬───────┐
│                         (index)                         │ Katalyst │ current │ diff  │
├─────────────────────────────────────────────────────────┼──────────┼─────────┼───────┤
│      t2e trade, type: SPLIT, fee: 123, reserves: 3      │  576101  │ 579550  │ 3449  │
│      e2t trade, type: SPLIT, fee: 123, reserves: 3      │  561132  │ 564591  │ 3459  │
│      t2t trade, type: SPLIT, fee: 123, reserves: 3      │  979449  │ 986706  │ 7257  │
│     t2e trade, type: NO HINT, fee: 123, reserves: 3     │  501635  │ 507031  │ 5396  │
│     e2t trade, type: NO HINT, fee: 123, reserves: 3     │  540672  │ 546100  │ 5428  │
│     t2t trade, type: NO HINT, fee: 123, reserves: 3     │  918403  │ 929274  │ 10871 │
│     t2e trade, type: MASK_IN, fee: 123, reserves: 3     │  393024  │ 396461  │ 3437  │
│     e2t trade, type: MASK_IN, fee: 123, reserves: 3     │  416721  │ 420168  │ 3447  │
│     t2t trade, type: MASK_IN, fee: 123, reserves: 3     │  691987  │ 698884  │ 6897  │
│    t2e trade, type: MASK_OUT, fee: 123, reserves: 2     │  404575  │ 408024  │ 3449  │
│    e2t trade, type: MASK_OUT, fee: 123, reserves: 2     │  427702  │ 431182  │ 3480  │
│    t2t trade, type: MASK_OUT, fee: 123, reserves: 2     │  715216  │ 722146  │ 6930  │
│  t2e trade maxdest, type: SPLIT, fee: 123, reserves: 3  │  560809  │ 564606  │ 3797  │
│  e2t trade maxdest, type: SPLIT, fee: 123, reserves: 3  │  574967  │ 578774  │ 3807  │
│  t2t trade maxdest, type: SPLIT, fee: 123, reserves: 3  │  998729  │ 1005985 │ 7256  │
│ t2e trade maxdest, type: NO HINT, fee: 123, reserves: 3 │  513066  │ 518520  │ 5454  │
│ e2t trade maxdest, type: NO HINT, fee: 123, reserves: 3 │  551079  │ 556507  │ 5428  │
│ t2t trade maxdest, type: NO HINT, fee: 123, reserves: 3 │  950683  │ 961321  │ 10638 │
└─────────────────────────────────────────────────────────┴──────────┴─────────┴───────┘
```

