### PR TITLE
Update campaign validation logics in KyberDao, add more get functions in KyberStaking

### DIFF
--- a/contracts/sol6/Dao/IKyberStaking.sol
+++ b/contracts/sol6/Dao/IKyberStaking.sol
@@ -27,7 +27,7 @@ interface IKyberStaking is IEpochUtils {
 
     function withdraw(uint256 amount) external;
 
-    function getStakerDataForPastEpoch(address staker, uint256 epoch)
+    function getStakerRawData(address staker, uint256 epoch)
         external
         view
         returns (

--- a/contracts/sol6/Dao/KyberDAO.sol
+++ b/contracts/sol6/Dao/KyberDAO.sol
@@ -594,7 +594,7 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
         }
 
         (uint256 stake, uint256 delegatedStake, address delegatedAddr) =
-            staking.getStakerDataForPastEpoch(staker, epoch);
+            staking.getStakerRawData(staker, epoch);
 
         uint256 totalStake = delegatedAddr == staker ? stake.add(delegatedStake) : delegatedStake;
         if (totalStake == 0) {

--- a/contracts/sol6/Dao/KyberStaking.sol
+++ b/contracts/sol6/Dao/KyberStaking.sol
@@ -95,9 +95,8 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
                 stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.add(updatedStake);
             stakerLatestData[dAddr].delegatedStake =
                 stakerLatestData[dAddr].delegatedStake.add(updatedStake);
+            emit Delegated(staker, dAddr, curEpoch, true);
         }
-
-        emit Delegated(staker, dAddr, curEpoch, true);
     }
 
     // prettier-ignore
@@ -201,11 +200,13 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     /**
+     * @notice return raw data of a staker for a specific epoch
+     *         WARN: data may not be accurate if data has not been inited
      * @dev  in DAO contract, if staker wants to claim reward for past epoch,
      *       we must know the staker's data for that epoch
      *       if the data has not been inited, it means staker hasn't done any action -> no reward
      */
-    function getStakerDataForPastEpoch(address staker, uint256 epoch)
+    function getStakerRawData(address staker, uint256 epoch)
         external
         view
         override
@@ -222,7 +223,6 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     /**
-     * @notice don't call on-chain, possibly high gas consumption
      * @dev allow to get data up to current epoch + 1
      */
     function getStake(address staker, uint256 epoch) external view returns (uint256) {
@@ -244,7 +244,6 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     /**
-     * @notice don't call on-chain, possibly high gas consumption
      * @dev allow to get data up to current epoch + 1
      */
     function getDelegatedStake(address staker, uint256 epoch) external view returns (uint256) {
@@ -266,7 +265,6 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     /**
-     * @notice don't call on-chain, possibly high gas consumption
      * @dev allow to get data up to current epoch + 1
      */
     function getDelegatedAddress(address staker, uint256 epoch) external view returns (address) {
@@ -288,6 +286,44 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         return staker;
     }
 
+    /**
+     * @notice return combine data (stake, delegatedStake, delegatedAddress) of a staker
+     * @dev allow to get staker data up to current epoch + 1
+     */
+    function getStakerData(address staker, uint256 epoch)
+        external view
+        returns (
+            uint256 stake,
+            uint256 delegatedStake,
+            address delegatedAddress
+        )
+    {
+        stake = 0;
+        delegatedStake = 0;
+        delegatedAddress = address(0);
+
+        uint256 curEpoch = getCurrentEpochNumber();
+        if (epoch > curEpoch + 1) {
+            return (stake, delegatedStake, delegatedAddress);
+        }
+        uint256 i = epoch;
+        while (true) {
+            if (hasInited[i][staker]) {
+                stake = stakerPerEpochData[i][staker].stake;
+                delegatedStake = stakerPerEpochData[i][staker].delegatedStake;
+                delegatedAddress = stakerPerEpochData[i][staker].delegatedAddress;
+                return (stake, delegatedStake, delegatedAddress);
+            }
+            if (i == 0) {
+                break;
+            }
+            i--;
+        }
+        // not delegated to anyone, default to yourself
+        delegatedAddress = staker;
+    }
+        
+
     function getLatestDelegatedAddress(address staker) external view returns (address) {
         return
             stakerLatestData[staker].delegatedAddress == address(0)
@@ -303,6 +339,21 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         return stakerLatestData[staker].stake;
     }
 
+    function getLatestStakerData(address staker)
+        external view
+        returns (
+            uint256 stake,
+            uint256 delegatedStake,
+            address delegatedAddress
+        )
+    {
+        stake = stakerLatestData[staker].stake;
+        delegatedStake = stakerLatestData[staker].delegatedStake;
+        delegatedAddress = stakerLatestData[staker].delegatedAddress == address(0)
+                ? staker
+                : stakerLatestData[staker].delegatedAddress;
+    }
+
     // prettier-ignore
     /**
     * @dev  separate logics from withdraw, so staker can withdraw as long as amount <= staker's deposit amount
@@ -315,7 +366,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         address staker,
         uint256 amount,
         uint256 curEpoch
-    ) public {
+    ) external {
         require(msg.sender == address(this), "only staking contract");
         initDataIfNeeded(staker, curEpoch);
         // Note: update latest stake will be done after this function

--- a/contracts/sol6/Dao/mock/MockKyberDaoMoreGetters.sol
+++ b/contracts/sol6/Dao/mock/MockKyberDaoMoreGetters.sol
@@ -7,9 +7,8 @@ contract MockKyberDaoMoreGetters is KyberDAO {
     constructor(
         uint256 _epochPeriod,
         uint256 _startTimestamp,
-        address _staking,
-        address _feeHandler,
-        address _knc,
+        IKyberFeeHandler _feeHandler,
+        IERC20 _knc,
         uint256 _minCampDuration,
         uint256 _defaultNetworkFeeBps,
         uint256 _defaultRewardBps,
@@ -20,7 +19,6 @@ contract MockKyberDaoMoreGetters is KyberDAO {
         KyberDAO(
             _epochPeriod,
             _startTimestamp,
-            _staking,
             _feeHandler,
             _knc,
             _defaultNetworkFeeBps,
@@ -33,7 +31,7 @@ contract MockKyberDaoMoreGetters is KyberDAO {
     }
 
     function replaceStakingContract(address _staking) public {
-        staking = IKyberStaking(_staking);
+        staking = KyberStaking(_staking);
     }
 
     function setLatestNetworkFee(uint256 _fee) public {

--- a/contracts/sol6/Dao/mock/MockKyberStakingMalicious.sol
+++ b/contracts/sol6/Dao/mock/MockKyberStakingMalicious.sol
@@ -5,10 +5,10 @@ import "../KyberStaking.sol";
 
 contract MockKyberStakingMalicious is KyberStaking {
     constructor(
-        address _kncToken,
+        IERC20 _kncToken,
         uint256 _epochPeriod,
         uint256 _startBlock,
-        address _admin
+        IKyberDAO _admin
     ) public KyberStaking(_kncToken, _epochPeriod, _startBlock, _admin) {}
 
     function setLatestStake(address staker, uint256 amount) public {

--- a/contracts/sol6/Dao/mock/MockMaliciousDAO.sol
+++ b/contracts/sol6/Dao/mock/MockMaliciousDAO.sol
@@ -7,9 +7,8 @@ contract MockMaliciousDAO is KyberDAO {
     constructor(
         uint256 _epochPeriod,
         uint256 _startTimestamp,
-        address _staking,
-        address _feeHandler,
-        address _knc,
+        IKyberFeeHandler _feeHandler,
+        IERC20 _knc,
         uint256 _minCampDuration,
         uint256 _defaultNetworkFeeBps,
         uint256 _defaultRewardBps,
@@ -20,7 +19,6 @@ contract MockMaliciousDAO is KyberDAO {
         KyberDAO(
             _epochPeriod,
             _startTimestamp,
-            _staking,
             _feeHandler,
             _knc,
             _defaultNetworkFeeBps,

--- a/contracts/sol6/Dao/mock/MockStakingContract.sol
+++ b/contracts/sol6/Dao/mock/MockStakingContract.sol
@@ -5,10 +5,10 @@ import "../KyberStaking.sol";
 
 contract MockStakingContract is KyberStaking {
     constructor(
-        address _kncToken,
+        IERC20 _kncToken,
         uint256 _epochPeriod,
         uint256 _startBlock,
-        address _admin
+        IKyberDAO _admin
     ) public KyberStaking(_kncToken, _epochPeriod, _startBlock, _admin) {}
 
     function setDAOAddressWithoutCheck(address dao) public {

--- a/test/sol6/kyberDao.js
+++ b/test/sol6/kyberDao.js
@@ -1042,7 +1042,7 @@ contract('KyberDAO', function(accounts) {
           1, startBlock + 2, startBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee for this epoch"
       );
 
       // still able to create for current epoch
@@ -1066,7 +1066,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 2, currentBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee for this epoch"
       );
       // still able to create camp of other types
       await updateCurrentBlockAndTimestamp();
@@ -1099,7 +1099,7 @@ contract('KyberDAO', function(accounts) {
           2, startBlock + 2, startBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr for this epoch"
       );
 
       // still able to create for current epoch
@@ -1124,7 +1124,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 2, currentBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr for this epoch"
       );
       // still able to create camp of other types
       await updateCurrentBlockAndTimestamp();
@@ -1457,27 +1457,32 @@ contract('KyberDAO', function(accounts) {
         ),
         "validateParams: min percentage is high"
       )
-      // cInPrecision > 2^128
+      // cInPrecision >= 2^128
       await expectRevert(
         submitNewCampaign(daoContract,
           0, currentBlock + 3, currentBlock + 3 + minCampPeriod,
-          precisionUnits, new BN(2).pow(new BN(128)).add(new BN(1)), tInPrecision,
+          precisionUnits, new BN(2).pow(new BN(128)), tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
         "validateParams: c is high"
       )
-      // tInPrecision > 2^128
+      // tInPrecision >= 2^128
       await expectRevert(
         submitNewCampaign(daoContract,
           0, currentBlock + 3, currentBlock + 3 + minCampPeriod,
-          precisionUnits, tInPrecision, new BN(2).pow(new BN(128)).add(new BN(1)),
+          precisionUnits, tInPrecision, new BN(2).pow(new BN(128)),
           [1, 2, 3], '0x', {from: daoOperator}
         ),
         "validateParams: t is high"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 5, currentBlock + 5 + minCampPeriod,
-        precisionUnits.sub(new BN(100)), cInPrecision, tInPrecision,
+        precisionUnits.sub(new BN(100)), new BN(2).pow(new BN(128)).sub(new BN(1)), tInPrecision,
+        [1, 2, 3], '0x', {from: daoOperator}
+      );
+      await submitNewCampaign(daoContract,
+        0, currentBlock + 5, currentBlock + 5 + minCampPeriod,
+        precisionUnits.sub(new BN(100)), cInPrecision, new BN(2).pow(new BN(128)).sub(new BN(1)),
         [1, 2, 3], '0x', {from: daoOperator}
       );
       await submitNewCampaign(daoContract,
@@ -1499,7 +1504,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1521,7 +1526,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1541,7 +1546,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1563,7 +1568,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1588,7 +1593,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime - minCampPeriod * blockTime, daoStartTime - 1, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
 
       await daoContract.cancelCampaign(1, {from: daoOperator});
@@ -1603,7 +1608,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime - minCampPeriod * blockTime, daoStartTime - 1, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
 
       for(let id = 0; id < maxCamps; id++) {
@@ -1617,7 +1622,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime, daoStartTime + minCampPeriod * blockTime, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
       await daoContract.cancelCampaign(await daoContract.numberCampaigns(), {from: daoOperator});
       await daoContract.submitNewCampaign(

--- a/test/sol6/kyberIntegration.js
+++ b/test/sol6/kyberIntegration.js
@@ -191,16 +191,15 @@ contract('Proxy + Network + MatchingEngine + FeeHandler + Staking + DAO integrat
         epochPeriod = _epochPeriod;
         startBlock = _startBlock;
         daoStartTime = blockToTimestamp(startBlock);
-        stakingContract = await StakingContract.new(KNC.address, blocksToSeconds(epochPeriod), daoStartTime, daoSetter);
 
         minCampPeriod = _campPeriod;
         daoContract = await MockDao.new(
             blocksToSeconds(epochPeriod), daoStartTime,
-            stakingContract.address,  feeHandler.address, KNC.address,
+            feeHandler.address, KNC.address,
             minCampPeriod, defaultNetworkFee, defaultRewardBps, defaultRebateBps,
             daoOperator
         )
-        await stakingContract.updateDAOAddressAndRemoveSetter(daoContract.address, {from: daoSetter});
+        stakingContract = await StakingContract.at(await daoContract.staking());
     };
 
     const setupSimpleStakingData = async() => {


### PR DESCRIPTION
This PR does following changes:
- KyberDao: Move all validations to validateCampaignParams when submit new campaign
- KyberDao: Avoid incompatible startTimestamp and startEpoch in validateCampaignParams function
- KyberDao: Make sure cInPrecision < 2^128 and tInPrecision < 2^128
- KyberStaking: Add functions to get all latest + per epoch data for a staker
- KyberStaking: Update function name for getting raw staker per epoch data