### PR TITLE
Update campaign validation logics in KyberDao, add more get functions in KyberStaking

### DIFF
--- a/contracts/sol6/Dao/IKyberStaking.sol
+++ b/contracts/sol6/Dao/IKyberStaking.sol
@@ -6,7 +6,7 @@ import "./IEpochUtils.sol";
 interface IKyberStaking is IEpochUtils {
     event Delegated(
         address indexed staker,
-        address indexed delegatedAddress,
+        address indexed representative,
         uint256 indexed epoch,
         bool isDelegated
     );
@@ -16,9 +16,9 @@ interface IKyberStaking is IEpochUtils {
     function initAndReturnStakerDataForCurrentEpoch(address staker)
         external
         returns (
-            uint256 _stake,
-            uint256 _delegatedStake,
-            address _delegatedAddress
+            uint256 stake,
+            uint256 delegatedStake,
+            address representative
         );
 
     function deposit(uint256 amount) external;
@@ -37,8 +37,8 @@ interface IKyberStaking is IEpochUtils {
         external
         view
         returns (
-            uint256 _stake,
-            uint256 _delegatedStake,
-            address _delegatedAddress
+            uint256 stake,
+            uint256 delegatedStake,
+            address representative
         );
 }

--- a/contracts/sol6/Dao/IKyberStaking.sol
+++ b/contracts/sol6/Dao/IKyberStaking.sol
@@ -27,7 +27,13 @@ interface IKyberStaking is IEpochUtils {
 
     function withdraw(uint256 amount) external;
 
-    function getStakerDataForPastEpoch(address staker, uint256 epoch)
+    /**
+     * @notice return raw data of a staker for an epoch
+     *         WARN: should be used only for initialized data
+     *          if data has not been initialized, it will return all 0
+     *          pool master shouldn't use this function to compute/distribute rewards of pool members
+     */
+    function getStakerRawData(address staker, uint256 epoch)
         external
         view
         returns (

--- a/contracts/sol6/Dao/KyberDAO.sol
+++ b/contracts/sol6/Dao/KyberDAO.sol
@@ -316,10 +316,10 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
         address staker = msg.sender;
 
         uint256 curEpoch = getCurrentEpochNumber();
-        (uint256 stake, uint256 dStake, address dAddress) =
+        (uint256 stake, uint256 dStake, address representative) =
             staking.initAndReturnStakerDataForCurrentEpoch(staker);
 
-        uint256 totalStake = dAddress == staker ? stake.add(dStake) : dStake;
+        uint256 totalStake = representative == staker ? stake.add(dStake) : dStake;
         uint256 lastVotedOption = stakerVotedOption[staker][campaignID];
 
         CampaignVoteData storage voteData = campaignData[campaignID].campaignVoteData;
@@ -589,10 +589,10 @@ contract KyberDAO is IKyberDAO, EpochUtils, ReentrancyGuard, Utils5, DaoOperator
             return 0;
         }
 
-        (uint256 stake, uint256 delegatedStake, address delegatedAddr) =
+        (uint256 stake, uint256 delegatedStake, address representative) =
             staking.getStakerRawData(staker, epoch);
 
-        uint256 totalStake = delegatedAddr == staker ? stake.add(delegatedStake) : delegatedStake;
+        uint256 totalStake = representative == staker ? stake.add(delegatedStake) : delegatedStake;
         if (totalStake == 0) {
             return 0;
         }

--- a/contracts/sol6/Dao/KyberStaking.sol
+++ b/contracts/sol6/Dao/KyberStaking.sol
@@ -16,7 +16,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     struct StakerData {
         uint256 stake;
         uint256 delegatedStake;
-        address delegatedAddress;
+        address representative;
     }
 
     IERC20 public kncToken;
@@ -24,7 +24,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
 
     // staker data per epoch
     mapping(uint256 => mapping(address => StakerData)) internal stakerPerEpochData;
-    // latest data of a staker, including stake, delegated stake, delegated address
+    // latest data of a staker, including stake, delegated stake, representative
     mapping(address => StakerData) internal stakerLatestData;
     // true/false: if we have inited data at an epoch for a staker
     mapping(uint256 => mapping(address => bool)) internal hasInited;
@@ -52,49 +52,49 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
 
     /**
      * @dev calls to set delegation for msg.sender, will take effect from the next epoch
-     * @param dAddr address to delegate to
+     * @param newRepresentative address to delegate to
      */
-    function delegate(address dAddr) external override {
-        require(dAddr != address(0), "delegate: delegated address 0");
+    function delegate(address newRepresentative) external override {
+        require(newRepresentative != address(0), "delegate: representative 0");
         address staker = msg.sender;
         uint256 curEpoch = getCurrentEpochNumber();
 
         initDataIfNeeded(staker, curEpoch);
 
-        address curDAddr = stakerPerEpochData[curEpoch + 1][staker].delegatedAddress;
+        address curRepresentative = stakerPerEpochData[curEpoch + 1][staker].representative;
         // nothing changes here
-        if (dAddr == curDAddr) {
+        if (newRepresentative == curRepresentative) {
             return;
         }
 
         uint256 updatedStake = stakerPerEpochData[curEpoch + 1][staker].stake;
 
-        // reduce delegatedStake for curDAddr if needed
-        if (curDAddr != staker) {
-            initDataIfNeeded(curDAddr, curEpoch);
+        // reduce delegatedStake for curRepresentative if needed
+        if (curRepresentative != staker) {
+            initDataIfNeeded(curRepresentative, curEpoch);
             // by right, delegatedStake should be greater than updatedStake
-            assert(stakerPerEpochData[curEpoch + 1][curDAddr].delegatedStake >= updatedStake);
-            assert(stakerLatestData[curDAddr].delegatedStake >= updatedStake);
+            assert(stakerPerEpochData[curEpoch + 1][curRepresentative].delegatedStake >= updatedStake);
+            assert(stakerLatestData[curRepresentative].delegatedStake >= updatedStake);
 
-            stakerPerEpochData[curEpoch + 1][curDAddr].delegatedStake =
-                stakerPerEpochData[curEpoch + 1][curDAddr].delegatedStake.sub(updatedStake);
-            stakerLatestData[curDAddr].delegatedStake =
-                stakerLatestData[curDAddr].delegatedStake.sub(updatedStake);
+            stakerPerEpochData[curEpoch + 1][curRepresentative].delegatedStake =
+                stakerPerEpochData[curEpoch + 1][curRepresentative].delegatedStake.sub(updatedStake);
+            stakerLatestData[curRepresentative].delegatedStake =
+                stakerLatestData[curRepresentative].delegatedStake.sub(updatedStake);
 
-            emit Delegated(staker, curDAddr, curEpoch, false);
+            emit Delegated(staker, curRepresentative, curEpoch, false);
         }
 
-        stakerLatestData[staker].delegatedAddress = dAddr;
-        stakerPerEpochData[curEpoch + 1][staker].delegatedAddress = dAddr;
+        stakerLatestData[staker].representative = newRepresentative;
+        stakerPerEpochData[curEpoch + 1][staker].representative = newRepresentative;
 
         // ignore if staker is delegating back to himself
-        if (dAddr != staker) {
-            initDataIfNeeded(dAddr, curEpoch);
-            stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake =
-                stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.add(updatedStake);
-            stakerLatestData[dAddr].delegatedStake =
-                stakerLatestData[dAddr].delegatedStake.add(updatedStake);
-            emit Delegated(staker, dAddr, curEpoch, true);
+        if (newRepresentative != staker) {
+            initDataIfNeeded(newRepresentative, curEpoch);
+            stakerPerEpochData[curEpoch + 1][newRepresentative].delegatedStake =
+                stakerPerEpochData[curEpoch + 1][newRepresentative].delegatedStake.add(updatedStake);
+            stakerLatestData[newRepresentative].delegatedStake =
+                stakerLatestData[newRepresentative].delegatedStake.add(updatedStake);
+            emit Delegated(staker, newRepresentative, curEpoch, true);
         }
     }
 
@@ -122,13 +122,13 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
             stakerLatestData[staker].stake.add(amount);
 
         // increase delegated stake for address that staker has delegated to (if it is not staker)
-        address dAddr = stakerPerEpochData[curEpoch + 1][staker].delegatedAddress;
-        if (dAddr != staker) {
-            initDataIfNeeded(dAddr, curEpoch);
-            stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake =
-                stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.add(amount);
-            stakerLatestData[dAddr].delegatedStake =
-                stakerLatestData[dAddr].delegatedStake.add(amount);
+        address representative = stakerPerEpochData[curEpoch + 1][staker].representative;
+        if (representative != staker) {
+            initDataIfNeeded(representative, curEpoch);
+            stakerPerEpochData[curEpoch + 1][representative].delegatedStake =
+                stakerPerEpochData[curEpoch + 1][representative].delegatedStake.add(amount);
+            stakerLatestData[representative].delegatedStake =
+                stakerLatestData[representative].delegatedStake.add(amount);
         }
 
         emit Deposited(curEpoch, staker, amount);
@@ -178,9 +178,9 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         external
         override
         returns (
-            uint256 _stake,
-            uint256 _delegatedStake,
-            address _delegatedAddress
+            uint256 stake,
+            uint256 delegatedStake,
+            address representative
         )
     {
         require(
@@ -192,9 +192,9 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         initDataIfNeeded(staker, curEpoch);
 
         StakerData memory stakerData = stakerPerEpochData[curEpoch][staker];
-        _stake = stakerData.stake;
-        _delegatedStake = stakerData.delegatedStake;
-        _delegatedAddress = stakerData.delegatedAddress;
+        stake = stakerData.stake;
+        delegatedStake = stakerData.delegatedStake;
+        representative = stakerData.representative;
     }
 
     /**
@@ -211,15 +211,15 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         view
         override
         returns (
-            uint256 _stake,
-            uint256 _delegatedStake,
-            address _delegatedAddress
+            uint256 stake,
+            uint256 delegatedStake,
+            address representative
         )
     {
         StakerData memory stakerData = stakerPerEpochData[epoch][staker];
-        _stake = stakerData.stake;
-        _delegatedStake = stakerData.delegatedStake;
-        _delegatedAddress = stakerData.delegatedAddress;
+        stake = stakerData.stake;
+        delegatedStake = stakerData.delegatedStake;
+        representative = stakerData.representative;
     }
 
     /**
@@ -267,7 +267,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     /**
      * @dev allow to get data up to current epoch + 1
      */
-    function getDelegatedAddress(address staker, uint256 epoch) external view returns (address) {
+    function getRepresentative(address staker, uint256 epoch) external view returns (address) {
         uint256 curEpoch = getCurrentEpochNumber();
         if (epoch > curEpoch + 1) {
             return address(0);
@@ -275,7 +275,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         uint256 i = epoch;
         while (true) {
             if (hasInited[i][staker]) {
-                return stakerPerEpochData[i][staker].delegatedAddress;
+                return stakerPerEpochData[i][staker].representative;
             }
             if (i == 0) {
                 break;
@@ -287,7 +287,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
     }
 
     /**
-     * @notice return combine data (stake, delegatedStake, delegatedAddress) of a staker
+     * @notice return combine data (stake, delegatedStake, representative) of a staker
      * @dev allow to get staker data up to current epoch + 1
      */
     function getStakerData(address staker, uint256 epoch)
@@ -295,24 +295,24 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         returns (
             uint256 stake,
             uint256 delegatedStake,
-            address delegatedAddress
+            address representative
         )
     {
         stake = 0;
         delegatedStake = 0;
-        delegatedAddress = address(0);
+        representative = address(0);
 
         uint256 curEpoch = getCurrentEpochNumber();
         if (epoch > curEpoch + 1) {
-            return (stake, delegatedStake, delegatedAddress);
+            return (stake, delegatedStake, representative);
         }
         uint256 i = epoch;
         while (true) {
             if (hasInited[i][staker]) {
                 stake = stakerPerEpochData[i][staker].stake;
                 delegatedStake = stakerPerEpochData[i][staker].delegatedStake;
-                delegatedAddress = stakerPerEpochData[i][staker].delegatedAddress;
-                return (stake, delegatedStake, delegatedAddress);
+                representative = stakerPerEpochData[i][staker].representative;
+                return (stake, delegatedStake, representative);
             }
             if (i == 0) {
                 break;
@@ -320,14 +320,14 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
             i--;
         }
         // not delegated to anyone, default to yourself
-        delegatedAddress = staker;
+        representative = staker;
     }
 
-    function getLatestDelegatedAddress(address staker) external view returns (address) {
+    function getLatestRepresentative(address staker) external view returns (address) {
         return
-            stakerLatestData[staker].delegatedAddress == address(0)
+            stakerLatestData[staker].representative == address(0)
                 ? staker
-                : stakerLatestData[staker].delegatedAddress;
+                : stakerLatestData[staker].representative;
     }
 
     function getLatestDelegatedStake(address staker) external view returns (uint256) {
@@ -343,14 +343,14 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         returns (
             uint256 stake,
             uint256 delegatedStake,
-            address delegatedAddress
+            address representative
         )
     {
         stake = stakerLatestData[staker].stake;
         delegatedStake = stakerLatestData[staker].delegatedStake;
-        delegatedAddress = stakerLatestData[staker].delegatedAddress == address(0)
+        representative = stakerLatestData[staker].representative == address(0)
                 ? staker
-                : stakerLatestData[staker].delegatedAddress;
+                : stakerLatestData[staker].representative;
     }
 
     /**
@@ -372,27 +372,27 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         stakerPerEpochData[curEpoch + 1][staker].stake =
             stakerPerEpochData[curEpoch + 1][staker].stake.sub(amount);
 
-        address dAddr = stakerPerEpochData[curEpoch][staker].delegatedAddress;
+        address representative = stakerPerEpochData[curEpoch][staker].representative;
         uint256 curStake = stakerPerEpochData[curEpoch][staker].stake;
         uint256 lStakeBal = stakerLatestData[staker].stake.sub(amount);
         uint256 newStake = curStake.min(lStakeBal);
         uint256 reduceAmount = curStake.sub(newStake); // newStake is always <= curStake
 
         if (reduceAmount > 0) {
-            if (dAddr != staker) {
-                initDataIfNeeded(dAddr, curEpoch);
-                // staker has delegated to dAddr, withdraw will affect dAddr's delegated stakes
-                stakerPerEpochData[curEpoch][dAddr].delegatedStake =
-                    stakerPerEpochData[curEpoch][dAddr].delegatedStake.sub(reduceAmount);
+            if (representative != staker) {
+                initDataIfNeeded(representative, curEpoch);
+                // staker has delegated to representative, withdraw will affect representative's delegated stakes
+                stakerPerEpochData[curEpoch][representative].delegatedStake =
+                    stakerPerEpochData[curEpoch][representative].delegatedStake.sub(reduceAmount);
             }
             stakerPerEpochData[curEpoch][staker].stake = newStake;
-            // call DAO to reduce reward, if staker has delegated, then pass his delegated address
+            // call DAO to reduce reward, if staker has delegated, then pass his representative
             if (address(daoContract) != address(0)) {
                 // don't revert if DAO revert so data will be updated correctly
                 (bool success, ) = address(daoContract).call(
                     abi.encodeWithSignature(
                         "handleWithdrawal(address,uint256)",
-                        dAddr,
+                        representative,
                         reduceAmount
                     )
                 );
@@ -401,13 +401,13 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
                 }
             }
         }
-        dAddr = stakerPerEpochData[curEpoch + 1][staker].delegatedAddress;
-        if (dAddr != staker) {
-            initDataIfNeeded(dAddr, curEpoch);
-            stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake =
-                stakerPerEpochData[curEpoch + 1][dAddr].delegatedStake.sub(amount);
-            stakerLatestData[dAddr].delegatedStake =
-                stakerLatestData[dAddr].delegatedStake.sub(amount);
+        representative = stakerPerEpochData[curEpoch + 1][staker].representative;
+        if (representative != staker) {
+            initDataIfNeeded(representative, curEpoch);
+            stakerPerEpochData[curEpoch + 1][representative].delegatedStake =
+                stakerPerEpochData[curEpoch + 1][representative].delegatedStake.sub(amount);
+            stakerLatestData[representative].delegatedStake =
+                stakerLatestData[representative].delegatedStake.sub(amount);
         }
     }
 
@@ -417,11 +417,11 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
      * @param epoch should be current epoch
      */
     function initDataIfNeeded(address staker, uint256 epoch) internal {
-        address ldAddress = stakerLatestData[staker].delegatedAddress;
-        if (ldAddress == address(0)) {
+        address representative = stakerLatestData[staker].representative;
+        if (representative == address(0)) {
             // not delegate to anyone, consider as delegate to yourself
-            stakerLatestData[staker].delegatedAddress = staker;
-            ldAddress = staker;
+            stakerLatestData[staker].representative = staker;
+            representative = staker;
         }
 
         uint256 ldStake = stakerLatestData[staker].delegatedStake;
@@ -430,7 +430,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         if (!hasInited[epoch][staker]) {
             hasInited[epoch][staker] = true;
             StakerData storage stakerData = stakerPerEpochData[epoch][staker];
-            stakerData.delegatedAddress = ldAddress;
+            stakerData.representative = representative;
             stakerData.delegatedStake = ldStake;
             stakerData.stake = lStakeBal;
         }
@@ -440,7 +440,7 @@ contract KyberStaking is IKyberStaking, EpochUtils, ReentrancyGuard {
         if (!hasInited[epoch + 1][staker]) {
             hasInited[epoch + 1][staker] = true;
             StakerData storage nextEpochStakerData = stakerPerEpochData[epoch + 1][staker];
-            nextEpochStakerData.delegatedAddress = ldAddress;
+            nextEpochStakerData.representative = representative;
             nextEpochStakerData.delegatedStake = ldStake;
             nextEpochStakerData.stake = lStakeBal;
         }

--- a/contracts/sol6/Dao/mock/MockStakingContract.sol
+++ b/contracts/sol6/Dao/mock/MockStakingContract.sol
@@ -27,11 +27,11 @@ contract MockStakingContract is KyberStaking {
         return stakerPerEpochData[epoch][staker].delegatedStake;
     }
 
-    function getDelegatedAddressValue(address staker, uint256 epoch)
+    function getRepresentativeValue(address staker, uint256 epoch)
         public
         view
         returns (address)
     {
-        return stakerPerEpochData[epoch][staker].delegatedAddress;
+        return stakerPerEpochData[epoch][staker].representative;
     }
 }

--- a/contracts/sol6/wrappers/KyberRateHelper.sol
+++ b/contracts/sol6/wrappers/KyberRateHelper.sol
@@ -90,7 +90,6 @@ contract KyberRateHelper is IKyberRateHelper, WithdrawableNoModifiers, Utils5 {
         return getRatesForTokenWithCustomFee(token, optionalBuyAmount, optionalSellAmount, feeBps);
     }
 
-    // prettier-ignore
     function getRatesForTokenWithCustomFee(
         IERC20 token,
         uint256 optionalBuyAmount,

--- a/test/sol6/kyberDao.js
+++ b/test/sol6/kyberDao.js
@@ -2577,7 +2577,7 @@ contract('KyberDAO', function(accounts) {
       Helper.assertEqual(1, await daoContract.getNumberVotes(mike, 1), "number votes should be correct");
       Helper.assertEqual(0, await daoContract.getNumberVotes(loi, 1), "number votes should be correct");
 
-      // Check: vote from someone has stake, no delegated stake, no delegated address
+      // Check: vote from someone has stake, no delegated stake, no representative
       await daoContract.vote(1, 1, {from: loi});
 
       epochPoints.iadd(initLoiStake);
@@ -2595,7 +2595,7 @@ contract('KyberDAO', function(accounts) {
       Helper.assertEqual(1, await daoContract.getNumberVotes(mike, 1), "number votes should be correct");
       Helper.assertEqual(1, await daoContract.getNumberVotes(loi, 1), "number votes should be correct");
 
-      // Check: withdraw from staker with no delegated address
+      // Check: withdraw from staker with no representative
       await stakingContract.withdraw(mulPrecision(100), {from: loi});
 
       epochPoints.isub(mulPrecision(100));
@@ -4065,12 +4065,12 @@ contract('KyberDAO', function(accounts) {
       totalEpochPoints.isub(mulPrecision(100 * 2));
       mikePoints.isub(mulPrecision(100 * 2));
 
-      // loi's delegated address voted 3 camp
+      // loi's representative voted 3 camp
       await stakingContract.withdraw(mulPrecision(150), {from: loi});
       totalEpochPoints.isub(mulPrecision(150 * 3));
       poolMasterPoints.isub(mulPrecision(150 * 3));
 
-      // victor's delegated address voted 1 camp
+      // victor's representative voted 1 camp
       await stakingContract.withdraw(mulPrecision(100), {from: victor});
       await stakingContract.withdraw(mulPrecision(50), {from: poolMaster2});
       totalEpochPoints.isub(mulPrecision(100 + 50));

--- a/test/sol6/kyberDao.js
+++ b/test/sol6/kyberDao.js
@@ -1042,7 +1042,7 @@ contract('KyberDAO', function(accounts) {
           1, startBlock + 2, startBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee campaign for this epoch"
       );
 
       // still able to create for current epoch
@@ -1066,7 +1066,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 2, currentBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee campaign for this epoch"
       );
       // still able to create camp of other types
       await updateCurrentBlockAndTimestamp();
@@ -1099,7 +1099,7 @@ contract('KyberDAO', function(accounts) {
           2, startBlock + 2, startBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr campaign for this epoch"
       );
 
       // still able to create for current epoch
@@ -1124,7 +1124,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 2, currentBlock + 2 + minCampPeriod,
           minPercentageInPrecision, cInPrecision, tInPrecision, [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr campaign for this epoch"
       );
       // still able to create camp of other types
       await updateCurrentBlockAndTimestamp();
@@ -1457,27 +1457,32 @@ contract('KyberDAO', function(accounts) {
         ),
         "validateParams: min percentage is high"
       )
-      // cInPrecision > 2^128
+      // cInPrecision >= 2^128
       await expectRevert(
         submitNewCampaign(daoContract,
           0, currentBlock + 3, currentBlock + 3 + minCampPeriod,
-          precisionUnits, new BN(2).pow(new BN(128)).add(new BN(1)), tInPrecision,
+          precisionUnits, new BN(2).pow(new BN(128)), tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
         "validateParams: c is high"
       )
-      // tInPrecision > 2^128
+      // tInPrecision >= 2^128
       await expectRevert(
         submitNewCampaign(daoContract,
           0, currentBlock + 3, currentBlock + 3 + minCampPeriod,
-          precisionUnits, tInPrecision, new BN(2).pow(new BN(128)).add(new BN(1)),
+          precisionUnits, tInPrecision, new BN(2).pow(new BN(128)),
           [1, 2, 3], '0x', {from: daoOperator}
         ),
         "validateParams: t is high"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 5, currentBlock + 5 + minCampPeriod,
-        precisionUnits.sub(new BN(100)), cInPrecision, tInPrecision,
+        precisionUnits.sub(new BN(100)), new BN(2).pow(new BN(128)).sub(new BN(1)), tInPrecision,
+        [1, 2, 3], '0x', {from: daoOperator}
+      );
+      await submitNewCampaign(daoContract,
+        0, currentBlock + 5, currentBlock + 5 + minCampPeriod,
+        precisionUnits.sub(new BN(100)), cInPrecision, new BN(2).pow(new BN(128)).sub(new BN(1)),
         [1, 2, 3], '0x', {from: daoOperator}
       );
       await submitNewCampaign(daoContract,
@@ -1499,7 +1504,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee campaign for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1521,7 +1526,7 @@ contract('KyberDAO', function(accounts) {
           1, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had network fee for this epoch"
+        "validateParams: already had network fee campaign for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1541,7 +1546,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr campaign for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1563,7 +1568,7 @@ contract('KyberDAO', function(accounts) {
           2, currentBlock + 6, currentBlock + 6 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: already had brr for this epoch"
+        "validateParams: already had brr campaign for this epoch"
       )
       await submitNewCampaign(daoContract,
         0, currentBlock + 8, currentBlock + 8 + minCampPeriod, minPercentageInPrecision, cInPrecision, tInPrecision,
@@ -1588,7 +1593,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime - minCampPeriod * blockTime, daoStartTime - 1, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
 
       await daoContract.cancelCampaign(1, {from: daoOperator});
@@ -1603,7 +1608,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime - minCampPeriod * blockTime, daoStartTime - 1, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
 
       for(let id = 0; id < maxCamps; id++) {
@@ -1617,7 +1622,7 @@ contract('KyberDAO', function(accounts) {
           0, daoStartTime, daoStartTime + minCampPeriod * blockTime, minPercentageInPrecision, cInPrecision, tInPrecision,
           [1, 2, 3], '0x', {from: daoOperator}
         ),
-        "newCampaign: too many campaigns"
+        "validateParams: too many campaigns"
       )
       await daoContract.cancelCampaign(await daoContract.numberCampaigns(), {from: daoOperator});
       await daoContract.submitNewCampaign(

--- a/test/sol6/kyberStaking.js
+++ b/test/sol6/kyberStaking.js
@@ -62,12 +62,12 @@ contract('KyberStaking', function(accounts) {
   };
 
   const checkInitAndReturnStakerDataForCurrentEpoch = async(
-	  staker, stake, delegatedStake, delegatedAddress, sender) => {
+	  staker, stake, delegatedStake, representative, sender) => {
 	await stakingContract.initAndReturnStakerDataForCurrentEpoch(staker, {from: sender});
 	let result = await stakingContract.initAndReturnStakerDataForCurrentEpoch.call(staker, {from: sender});
-	Helper.assertEqual(stake, result._stake);
-	Helper.assertEqual(delegatedStake, result._delegatedStake);
-	Helper.assertEqual(delegatedAddress, result._delegatedAddress);
+	Helper.assertEqual(stake, result.stake);
+	Helper.assertEqual(delegatedStake, result.delegatedStake);
+	Helper.assertEqual(representative, result.representative);
   };
 
   it("Test get epoch number returns correct data", async function() {
@@ -346,7 +346,7 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 0), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "delegated addres is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(mike), "delegated stake is wrong");
 
       await stakingContract.deposit(mulPrecision(20), {from: victor});
@@ -362,7 +362,7 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(mulPrecision(120), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(150), await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(150), await stakingContract.getLatestDelegatedStake(mike), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 2), "delegated addres is wrong");
 
       // delay few epochs
       await Helper.increaseNextBlockTimestamp(
@@ -372,7 +372,7 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(mulPrecision(150), await stakingContract.getDelegatedStake(mike, 5), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(200), await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(200), await stakingContract.getLatestDelegatedStake(mike), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 6), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 6), "delegated addres is wrong");
     });
 
     it("Test deposit then delegate, then delegate again at same + different epoch", async function() {
@@ -386,7 +386,7 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 0), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "delegated addres is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(mike), "delegated stake is wrong");
 
       await stakingContract.delegate(loi, {from: victor});
@@ -394,7 +394,7 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated addres is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 1), "delegated addres is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(loi), "delegated stake is wrong");
 
@@ -405,9 +405,9 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 2), "delegated addres is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated addres is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 1), "delegated addres is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 2), "delegated stake is wrong");
       Helper.assertEqual(0, await stakingContract.getLatestDelegatedStake(loi), "delegated stake is wrong");
@@ -419,10 +419,10 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 5), "delegated stake is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 5), "delegated addres is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 5), "delegated addres is wrong");
       Helper.assertEqual(0, await stakingContract.getLatestDelegatedStake(mike), "delegated stake is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 6), "delegated addres is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 6), "delegated addres is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 5), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(loi, 6), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(loi), "delegated stake is wrong");
@@ -1175,7 +1175,7 @@ contract('KyberStaking', function(accounts) {
   });
 
   describe("#Delegate Tests", () => {
-    it("Test delegate, delegated address and stake change as expected", async function() {
+    it("Test delegate, representative and stake change as expected", async function() {
       await deployStakingContract(10, currentBlock + 10);
 
       await kncToken.transfer(victor, mulPrecision(100));
@@ -1184,7 +1184,7 @@ contract('KyberStaking', function(accounts) {
       let tx = await stakingContract.delegate(mike, {from: victor});
       expectEvent(tx, "Delegated", {
         staker: victor,
-        delegatedAddress: mike,
+        representative: mike,
         epoch: new BN(0),
         isDelegated: true
       });
@@ -1195,7 +1195,7 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.deposit(mulPrecision(50), {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 5), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is incorrect");
@@ -1203,18 +1203,18 @@ contract('KyberStaking', function(accounts) {
       tx = await stakingContract.delegate(loi, {from: victor});
       expectEvent(tx, "Delegated", {
         staker: victor,
-        delegatedAddress: mike,
+        representative: mike,
         epoch: new BN(5),
         isDelegated: false
       });
       expectEvent(tx, "Delegated", {
         staker: victor,
-        delegatedAddress: loi,
+        representative: loi,
         epoch: new BN(5),
         isDelegated: true
       });
 
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(0, await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is incorrect");
 
@@ -1236,7 +1236,7 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 9), "delegated stake is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStake(loi, 9), "delegated stake is incorrect");
@@ -1271,14 +1271,14 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.deposit(mulPrecision(50), {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 5), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
 
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 5), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
@@ -1289,7 +1289,7 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStake(mike, 10), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
     });
@@ -1307,13 +1307,13 @@ contract('KyberStaking', function(accounts) {
         blockToTimestamp(4 * epochPeriod + startBlock)
       );
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStake(mike, 4), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
 
       await stakingContract.delegate(victor, {from: victor});
 
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       // delegate back to yourself, shouldn't have any delegated stake
       Helper.assertEqual(0, await stakingContract.getLatestDelegatedStake(victor), "latest delegated stake is incorrect");
 
@@ -1335,7 +1335,7 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is incorrect");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is incorrect");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is incorrect");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 5), "delegated stake is incorrect");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 6), "delegated stake is incorrect");
@@ -1391,8 +1391,8 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(mulPrecision(200), await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(200), await stakingContract.getLatestDelegatedStake(loi), "latest delegated stake is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(victor), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(victor), "representative is wrong");
 
       await Helper.increaseNextBlockTimestamp(
         blocksToSeconds(4 * epochPeriod)
@@ -1401,15 +1401,15 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(mulPrecision(190), await stakingContract.getDelegatedStakesValue(loi, 4), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(190), await stakingContract.getLatestDelegatedStake(loi), "latest delegated stake is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(victor), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(victor), "representative is wrong");
 
       await stakingContract.delegate(victor, {from: victor});
 
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(loi, 5), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(loi), "latest delegated stake is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "delegated address is wrong");
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(victor), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "representative is wrong");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(victor), "representative is wrong");
     });
 
     it("Test delegate then withdraw, stakes change as expected", async function() {
@@ -1507,8 +1507,8 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(mulPrecision(300), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is wrong");
       Helper.assertEqual(mulPrecision(300), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 0), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated address is wrong");
-      Helper.assertEqual(victor, await stakingContract.getDelegatedAddressValue(victor, 0), "delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "representative is wrong");
+      Helper.assertEqual(victor, await stakingContract.getRepresentativeValue(victor, 0), "representative is wrong");
 
       await Helper.setNextBlockTimestamp(
         blockToTimestamp(epochPeriod + startBlock)
@@ -1524,8 +1524,8 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 2), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(300), await stakingContract.getDelegatedStakesValue(loi, 3), "delegated stake is wrong");
 
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 3), "delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 2), "representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 3), "representative is wrong");
     });
 
     it("Test delegate circulation, data changes as expect", async function() {
@@ -1549,18 +1549,18 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(mulPrecision(100), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(mike, 1), "delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(mike, 1), "representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
 
       Helper.assertEqual(mulPrecision(200), await stakingContract.getLatestDelegatedStake(loi), "latest delegated stake is wrong");
       Helper.assertEqual(mulPrecision(200), await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
-      Helper.assertEqual(victor, await stakingContract.getDelegatedAddressValue(loi, 1), "delegated address is wrong");
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(victor, await stakingContract.getRepresentativeValue(loi, 1), "representative is wrong");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       Helper.assertEqual(mulPrecision(300), await stakingContract.getLatestDelegatedStake(victor), "latest delegated stake is wrong");
       Helper.assertEqual(mulPrecision(300), await stakingContract.getDelegatedStakesValue(victor, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
 
       await Helper.setNextBlockTimestamp(
         blockToTimestamp(startBlock + 1)
@@ -1612,28 +1612,28 @@ contract('KyberStaking', function(accounts) {
 
       await stakingContract.delegate(loi, {from: victor});
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 2), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(loi, 2), "delegated stake is wrong");
 
       await stakingContract.deposit(mulPrecision(100), {from: victor});
       Helper.assertEqual(mulPrecision(100), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 2), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(200), await stakingContract.getDelegatedStakesValue(loi, 2), "delegated stake is wrong");
 
       await stakingContract.withdraw(mulPrecision(150), {from: victor});
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStakesValue(mike, 1), "delegated stake is wrong");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddressValue(victor, 1), "delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getRepresentativeValue(victor, 1), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(mike, 2), "delegated stake is wrong");
 
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddressValue(victor, 2), "delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getRepresentativeValue(victor, 2), "representative is wrong");
       Helper.assertEqual(0, await stakingContract.getDelegatedStakesValue(loi, 1), "delegated stake is wrong");
       Helper.assertEqual(mulPrecision(50), await stakingContract.getDelegatedStakesValue(loi, 2), "delegated stake is wrong");
     });
@@ -1757,7 +1757,7 @@ contract('KyberStaking', function(accounts) {
       logInfo("Delegate has stake: no init epoch data + from mike to loi, gas used: " + tx.receipt.gasUsed);
 
       tx = await stakingContract.delegate(loi, {from: victor});
-      logInfo("Delegate has stake: same delegated address, gas used: " + tx.receipt.gasUsed);
+      logInfo("Delegate has stake: same representative, gas used: " + tx.receipt.gasUsed);
       tx = await stakingContract.delegate(victor, {from: victor});
       logInfo("Delegate has stake: back to self, gas used: " + tx.receipt.gasUsed);
     });
@@ -1773,7 +1773,7 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(0, await stakingContract.getStake(victor, 100), "get stakes should return 0");
       Helper.assertEqual(0, await stakingContract.getDelegatedStake(victor, 100), "get stakes should return 0");
-      Helper.assertEqual(zeroAddress, await stakingContract.getDelegatedAddress(victor, 100), "get stakes should return 0");
+      Helper.assertEqual(zeroAddress, await stakingContract.getRepresentative(victor, 100), "get stakes should return 0");
     });
 
     it("Test getStake returns correct data", async function() {
@@ -1873,28 +1873,28 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(0, await stakingContract.getDelegatedStake(victor, 100), "get delegated stake should return correct data");
     });
 
-    it("Test getDelegatedAddress returns correct data", async function() {
+    it("Test getRepresentative returns correct data", async function() {
       await deployStakingContract(6, currentBlock + 10);
 
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(mike, 0), "get delegated address should return correct data");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(mike, 1), "get delegated address should return correct data");
-      Helper.assertEqual(victor, await stakingContract.getDelegatedAddress(victor, 0), "get delegated address should return correct data");
-      Helper.assertEqual(victor, await stakingContract.getDelegatedAddress(victor, 1), "get delegated address should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(mike, 0), "get representative should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(mike, 1), "get representative should return correct data");
+      Helper.assertEqual(victor, await stakingContract.getRepresentative(victor, 0), "get representative should return correct data");
+      Helper.assertEqual(victor, await stakingContract.getRepresentative(victor, 1), "get representative should return correct data");
 
       await kncToken.transfer(victor, mulPrecision(200));
       await kncToken.approve(stakingContract.address, mulPrecision(200), {from: victor});
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(victor, await stakingContract.getDelegatedAddress(victor, 0), "get delegated address should return correct data");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(victor, 1), "get delegated address should return correct data");
+      Helper.assertEqual(victor, await stakingContract.getRepresentative(victor, 0), "get representative should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(victor, 1), "get representative should return correct data");
 
       await Helper.mineNewBlockAt(
         blockToTimestamp(3 * epochPeriod + startBlock)
       );
 
       // get data current + next epoch
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(victor, 4), "get delegated address should return correct data");
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(victor, 5), "get delegated address should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(victor, 4), "get representative should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(victor, 5), "get representative should return correct data");
 
       currentBlock = await Helper.getCurrentBlock();
       await Helper.mineNewBlockAfter(
@@ -1902,17 +1902,17 @@ contract('KyberStaking', function(accounts) {
       );
 
       // get data for past epoch
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(mike, 7), "get delegated address should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(mike, 7), "get representative should return correct data");
 
       await stakingContract.delegate(loi, {from: victor});
       // get data for pass epoch
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(victor, 7), "get delegated address should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(victor, 7), "get representative should return correct data");
 
       // get data for current epoch
-      Helper.assertEqual(mike, await stakingContract.getDelegatedAddress(victor, 10), "get delegated address should return correct data");
-      Helper.assertEqual(loi, await stakingContract.getDelegatedAddress(victor, 11), "get delegated address should return correct data");
+      Helper.assertEqual(mike, await stakingContract.getRepresentative(victor, 10), "get representative should return correct data");
+      Helper.assertEqual(loi, await stakingContract.getRepresentative(victor, 11), "get representative should return correct data");
 
-      Helper.assertEqual(zeroAddress, await stakingContract.getDelegatedAddress(victor, 100), "get delegated address should return correct data");
+      Helper.assertEqual(zeroAddress, await stakingContract.getRepresentative(victor, 100), "get representative should return correct data");
     });
 
     it("Test getStake returns correct data", async function() {
@@ -1926,19 +1926,19 @@ contract('KyberStaking', function(accounts) {
       let data = await stakingContract.getStakerRawData(victor, 0);
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(zeroAddress, data[2], "delegated address is wrong");
+      Helper.assertEqual(zeroAddress, data[2], "representative is wrong");
 
       await stakingContract.deposit(mulPrecision(50), {from: victor});
 
       data = await stakingContract.getStakerRawData(victor, 0);
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(victor, data[2], "delegated address is wrong");
+      Helper.assertEqual(victor, data[2], "representative is wrong");
 
       data = await stakingContract.getStakerRawData(victor, 1);
       Helper.assertEqual(mulPrecision(50), data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(victor, data[2], "delegated address is wrong");
+      Helper.assertEqual(victor, data[2], "representative is wrong");
 
       await Helper.setNextBlockTimestamp(
         blockToTimestamp(startBlock)
@@ -1954,7 +1954,7 @@ contract('KyberStaking', function(accounts) {
       // not inited yet
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(zeroAddress, data[2], "delegated address is wrong");
+      Helper.assertEqual(zeroAddress, data[2], "representative is wrong");
 
       await Helper.setNextBlockTimestamp(
         blockToTimestamp(6 * epochPeriod + startBlock)
@@ -1964,28 +1964,28 @@ contract('KyberStaking', function(accounts) {
       // not inited yet
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(zeroAddress, data[2], "delegated address is wrong");
+      Helper.assertEqual(zeroAddress, data[2], "representative is wrong");
 
       await stakingContract.delegate(mike, {from: victor});
       data = await stakingContract.getStakerRawData(mike, 7);
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
       data = await stakingContract.getStakerRawData(mike, 8);
       Helper.assertEqual(0, data[0], "stake is wrong");
       Helper.assertEqual(mulPrecision(70), data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       await stakingContract.deposit(mulPrecision(100), {from: mike});
       data = await stakingContract.getStakerRawData(mike, 8);
       Helper.assertEqual(mulPrecision(100), data[0], "stake is wrong");
       Helper.assertEqual(mulPrecision(70), data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       data = await stakingContract.getStakerRawData(victor, 8);
       Helper.assertEqual(mulPrecision(70), data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       await Helper.setNextBlockTimestamp(
         blockToTimestamp(7 * epochPeriod + startBlock)
@@ -1996,12 +1996,12 @@ contract('KyberStaking', function(accounts) {
       data = await stakingContract.getStakerRawData(mike, 8);
       Helper.assertEqual(mulPrecision(100), data[0], "stake is wrong");
       Helper.assertEqual(mulPrecision(70), data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       data = await stakingContract.getStakerRawData(mike, 9);
       Helper.assertEqual(mulPrecision(100), data[0], "stake is wrong");
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       data = await stakingContract.getStakerRawData(loi, 8);
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
@@ -2011,11 +2011,11 @@ contract('KyberStaking', function(accounts) {
 
       data = await stakingContract.getStakerRawData(victor, 8);
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(mike, data[2], "delegated address is wrong");
+      Helper.assertEqual(mike, data[2], "representative is wrong");
 
       data = await stakingContract.getStakerRawData(victor, 9);
       Helper.assertEqual(0, data[1], "delegated stake is wrong");
-      Helper.assertEqual(loi, data[2], "delegated address is wrong");
+      Helper.assertEqual(loi, data[2], "representative is wrong");
     });
 
     it("Test get latest stake returns correct data", async function() {
@@ -2137,53 +2137,53 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(mulPrecision(50), await stakingContract.getLatestDelegatedStake(mike), "latest delegated stake is wrong");
     });
 
-    it("Test get delegated address returns correct data", async function() {
+    it("Test get representative returns correct data", async function() {
       await deployStakingContract(6, currentBlock + 10);
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await Helper.increaseNextBlockTimestamp(
         blocksToSeconds(20)
       );
       await stakingContract.delegate(mike, {from: victor});
 
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await stakingContract.delegate(victor, {from: loi});
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await stakingContract.delegate(mike, {from: loi});
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await stakingContract.delegate(loi, {from: mike});
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await Helper.increaseNextBlockTimestamp(
         blocksToSeconds(25)
       );
-      Helper.assertEqual(loi, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(loi, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await stakingContract.delegate(mike, {from: mike});
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
 
       await stakingContract.delegate(victor, {from: mike});
-      Helper.assertEqual(victor, await stakingContract.getLatestDelegatedAddress(mike), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(victor), "latest delegated address is wrong");
-      Helper.assertEqual(mike, await stakingContract.getLatestDelegatedAddress(loi), "latest delegated address is wrong");
+      Helper.assertEqual(victor, await stakingContract.getLatestRepresentative(mike), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(victor), "latest representative is wrong");
+      Helper.assertEqual(mike, await stakingContract.getLatestRepresentative(loi), "latest representative is wrong");
     });
 
     it("test get staker data returns correct data", async function() {
@@ -2388,7 +2388,7 @@ contract('KyberStaking', function(accounts) {
 
       Helper.assertEqual(false, await stakingContract.getHasInitedValue(victor, 2), "shouldn't inited value for epoch 2");
 
-      // victor: stake (100), delegated stake (0), delegated address (victor)
+      // victor: stake (100), delegated stake (0), representative (victor)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         victor, mulPrecision(100), 0, victor, daoContract
       );
@@ -2396,12 +2396,12 @@ contract('KyberStaking', function(accounts) {
       Helper.assertEqual(true, await stakingContract.getHasInitedValue(victor, 3), "should inited value for epoch 3");
 
       await stakingContract.delegate(mike, {from: victor});
-      // victor: stake (100), delegated stake (0), delegated address (victor)
+      // victor: stake (100), delegated stake (0), representative (victor)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         victor, mulPrecision(100), 0, victor, daoContract
       );
 
-      // mike: stake (0), delegated stake (0), delegated address (mike)
+      // mike: stake (0), delegated stake (0), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         mike, 0, 0, mike, daoContract
       );
@@ -2412,34 +2412,34 @@ contract('KyberStaking', function(accounts) {
         blockToTimestamp(2 * epochPeriod + startBlock)
       );
 
-      // victor: stake (100), delegated stake (0), delegated address (mike)
+      // victor: stake (100), delegated stake (0), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         victor, mulPrecision(100), 0, mike, daoContract
       );
 
-      // mike: stake (200), delegated stake (100), delegated address (mike)
+      // mike: stake (200), delegated stake (100), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         mike, mulPrecision(200), mulPrecision(100), mike, daoContract
       );
 
       await stakingContract.delegate(loi, {from: victor});
 
-      // mike: stake (200), delegated stake (100), delegated address (mike)
+      // mike: stake (200), delegated stake (100), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         mike, mulPrecision(200), mulPrecision(100), mike, daoContract
       );
-      // loi: stake (0), delegated stake (0), delegated address (loi)
+      // loi: stake (0), delegated stake (0), representative (loi)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         loi, 0, 0, loi, daoContract
       );
 
       await stakingContract.deposit(mulPrecision(10), {from: victor});
-      // loi: stake (0), delegated stake (0), delegated address (loi)
+      // loi: stake (0), delegated stake (0), representative (loi)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         loi, 0, 0, loi, daoContract
       );
 
-      // mike: stake (200), delegated stake (100), delegated address (mike)
+      // mike: stake (200), delegated stake (100), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         mike, mulPrecision(200), mulPrecision(100), mike, daoContract
       );
@@ -2448,12 +2448,12 @@ contract('KyberStaking', function(accounts) {
         blockToTimestamp(3 * epochPeriod + startBlock)
       );
 
-      // mike: stake (200), delegated stake (0), delegated address (mike)
+      // mike: stake (200), delegated stake (0), representative (mike)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         mike, mulPrecision(200), 0, mike, daoContract
       );
 
-      // loi: stake (0), delegated stake (90), delegated address (loi)
+      // loi: stake (0), delegated stake (90), representative (loi)
       await checkInitAndReturnStakerDataForCurrentEpoch(
         loi, 0, mulPrecision(110), loi, daoContract
       );
@@ -2654,7 +2654,7 @@ contract('KyberStaking', function(accounts) {
 
       await expectRevert(
         stakingContract.delegate(zeroAddress, {from: victor}),
-        "delegate: delegated address 0"
+        "delegate: representative 0"
       )
       await stakingContract.delegate(mike, {from: victor});
     });
@@ -2668,18 +2668,18 @@ contract('KyberStaking', function(accounts) {
     let curStake = await stakingContract.getStake(staker, epoch);
     let hasInitCurStake = await stakingContract.getHasInitedValue(staker, epoch);
     let nextStake = await stakingContract.getStake(staker, epoch+1);
-    // current delegated address
-    let curDAddress = await stakingContract.getDelegatedAddress(staker, epoch);
-    // current delegated address's delegated stake
+    // current representative
+    let curDAddress = await stakingContract.getRepresentative(staker, epoch);
+    // current representative's delegated stake
     let dStakeCurDAddress = await stakingContract.getDelegatedStake(curDAddress, epoch);
-    // current delegated address's latest delegated stake
+    // current representative's latest delegated stake
     let ldStakeCurDAddress = await stakingContract.getLatestDelegatedStake(curDAddress);
     let hasInitCurDAddress = await stakingContract.getHasInitedValue(curDAddress, epoch);
-    // next delegated address
-    let nextDAddress = await stakingContract.getDelegatedAddress(staker, epoch+1);
-    // next delegated address's latest delegated stake
+    // next representative
+    let nextDAddress = await stakingContract.getRepresentative(staker, epoch+1);
+    // next representative's latest delegated stake
     let ldStakeNextDAddress = await stakingContract.getLatestDelegatedStake(nextDAddress);
-    // next delegated address's delegated stake
+    // next representative's delegated stake
     let dStakeNextDAddress = await stakingContract.getDelegatedStake(nextDAddress, epoch+1);
     let hasInitNextDAddress = await stakingContract.getHasInitedValue(nextDAddress, epoch);
 
@@ -2947,10 +2947,10 @@ contract('KyberStaking', function(accounts) {
   });
 });
 
-function verifyStakerData(stakerData, stake, delegatedStake, delegatedAddress) {
+function verifyStakerData(stakerData, stake, delegatedStake, representative) {
   Helper.assertEqual(stake, stakerData.stake, "stake is wrong");
   Helper.assertEqual(delegatedStake, stakerData.delegatedStake, "delegated stake is wrong");
-  Helper.assertEqual(delegatedAddress, stakerData.delegatedAddress, "delegated address is wrong");
+  Helper.assertEqual(representative, stakerData.representative, "representative is wrong");
 }
 
 function logInfo(message) {


### PR DESCRIPTION
This PR does following changes:
- KyberDao: Move all validations to validateCampaignParams when submit new campaign
- KyberDao: Avoid incompatible startTimestamp and startEpoch in validateCampaignParams function
- KyberDao: Make sure cInPrecision < 2^128 and tInPrecision < 2^128
- KyberStaking: Add functions to get all latest + per epoch data for a staker
- KyberStaking: Update function name for getting raw staker per epoch data
- KyberStaking: Change delegatedAddress -> representative