### PR TITLE
set reentrancy block when call trade during claim platformFee and rebate

### DIFF
--- a/contracts/sol6/IKyberFeeHandler.sol
+++ b/contracts/sol6/IKyberFeeHandler.sol
@@ -16,6 +16,8 @@ interface IKyberFeeHandler {
 
     function claimReserveRebate(address rebateWallet) external returns (uint256);
 
+    function claimPlatformFee(address platformWallet) external returns (uint256);
+
     function claimStakerReward(
         address staker,
         uint256 percentageInPrecision,

--- a/contracts/sol6/mock/ReentrancyFeeClaimer.sol
+++ b/contracts/sol6/mock/ReentrancyFeeClaimer.sol
@@ -1,0 +1,51 @@
+pragma solidity 0.6.6;
+
+import "../IKyberNetworkProxy.sol";
+import "../utils/Utils5.sol";
+import "../IKyberFeeHandler.sol";
+
+/// @dev contract to call trade when claimPlatformFee
+contract ReentrancyFeeClaimer is Utils5 {
+    IKyberNetworkProxy kyberProxy;
+    IKyberFeeHandler feeHandler;
+    IERC20 token;
+    uint256 amount;
+
+    bool isReentrancy = true;
+
+    constructor(
+        IKyberNetworkProxy _kyberProxy,
+        IKyberFeeHandler _feeHandler,
+        IERC20 _token,
+        uint256 _amount
+    ) public {
+        kyberProxy = _kyberProxy;
+        feeHandler = _feeHandler;
+        token = _token;
+        amount = _amount;
+        require(_token.approve(address(_kyberProxy), _amount));
+    }
+
+    function setReentrancy(bool _isReentrancy) external {
+        isReentrancy = _isReentrancy;
+    }
+
+    receive() external payable {
+        if (!isReentrancy) {
+            return;
+        }
+
+        bytes memory hint;
+        kyberProxy.tradeWithHintAndFee(
+            token,
+            amount,
+            ETH_TOKEN_ADDRESS,
+            msg.sender,
+            MAX_QTY,
+            0,
+            address(this),
+            100,
+            hint
+        );
+    }
+}


### PR DESCRIPTION
Case:
- The platform has the fee of 5 wei
- call **claimPlatformFee** -> receive 4 wei
- trigger callback function -> Earn some more platform fees
- PlatformFeePaid emitted.
-> platform fee is not reset to 1

In this PR:
- add reentrancy guard to claimPlatformFee, handleFees, claimReserveRebate
- add claimPlatformFee to IKyberFeeHandler