### PR TITLE
update token.approve to max allowance in kyberNetwork contract. from '2**255' to '2*256-1'

### DIFF
--- a/contracts/sol6/KyberNetwork.sol
+++ b/contracts/sol6/KyberNetwork.sol
@@ -225,7 +225,7 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
         require(msg.sender == address(kyberStorage), "only kyberStorage");
 
         if (add) {
-            token.safeApprove(reserve, 2**255);
+            token.safeApprove(reserve, MAX_ALLOWANCE);
             setDecimals(token);
         } else {
             token.safeApprove(reserve, 0);
@@ -264,7 +264,7 @@ contract KyberNetwork is WithdrawableNoModifiers, Utils5, IKyberNetwork, Reentra
 
         for(uint i = 0; i < reserves.length; i++) {
             if (add) {
-                token.safeApprove(reserves[i], 2**255);
+                token.safeApprove(reserves[i], MAX_ALLOWANCE);
                 setDecimals(token);
             } else {
                 token.safeApprove(reserves[i], 0);

--- a/contracts/sol6/utils/Utils5.sol
+++ b/contracts/sol6/utils/Utils5.sol
@@ -19,6 +19,7 @@ contract Utils5 {
     uint256 internal constant MAX_DECIMALS = 18;
     uint256 internal constant ETH_DECIMALS = 18;
     uint256 constant BPS = 10000; // Basic Price Steps. 1 step = 0.01%
+    uint256 internal constant MAX_ALLOWANCE = 2**256 - 1; // token.approve inifinite
 
     mapping(IERC20 => uint256) internal decimals;
 

--- a/contracts/sol6/utils/Utils5.sol
+++ b/contracts/sol6/utils/Utils5.sol
@@ -19,7 +19,7 @@ contract Utils5 {
     uint256 internal constant MAX_DECIMALS = 18;
     uint256 internal constant ETH_DECIMALS = 18;
     uint256 constant BPS = 10000; // Basic Price Steps. 1 step = 0.01%
-    uint256 internal constant MAX_ALLOWANCE = 2**256 - 1; // token.approve inifinite
+    uint256 internal constant MAX_ALLOWANCE = uint256(-1); // token.approve inifinite
 
     mapping(IERC20 => uint256) internal decimals;
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -15,7 +15,9 @@ const emptyHint = '0x';
 const zeroBN = new BN(0);
 const MAX_QTY = new BN(10).pow(new BN(28));
 const MAX_RATE = precisionUnits.mul(new BN(10).pow(new BN(7)));
-module.exports = {BPS, precisionUnits, ethDecimals, ethAddress, zeroAddress, emptyHint, zeroBN, MAX_QTY, MAX_RATE};
+const MAX_ALLOWANCE = ((new BN(2)).pow(new BN(256))).sub(new BN(1));
+module.exports = {BPS, precisionUnits, ethDecimals, ethAddress, zeroAddress, 
+  emptyHint, zeroBN, MAX_QTY, MAX_RATE, MAX_ALLOWANCE};
 
 module.exports.isRevertErrorMessageContains = function(error, msg) {
     return (error.message.search(msg) >= 0);

--- a/test/sol6/kyberNetwork.js
+++ b/test/sol6/kyberNetwork.js
@@ -25,7 +25,8 @@ const nwHelper = require("./networkHelper.js");
 const BN = web3.utils.BN;
 const { expectEvent, expectRevert } = require('@openzeppelin/test-helpers');
 
-const {BPS, precisionUnits, ethDecimals, ethAddress, zeroAddress, emptyHint, zeroBN, MAX_QTY, MAX_RATE} = require("../helper.js");
+const {BPS, precisionUnits, ethDecimals, ethAddress, zeroAddress, emptyHint, 
+    zeroBN, MAX_QTY, MAX_RATE, MAX_ALLOWANCE} = require("../helper.js");
 const {APR_ID, BRIDGE_ID, MOCK_ID, FPR_ID, type_apr, type_fpr, type_MOCK,
     MASK_IN_HINTTYPE, MASK_OUT_HINTTYPE, SPLIT_HINTTYPE, BEST_OF_ALL_HINTTYPE, ReserveType}  = require('./networkHelper.js');
 
@@ -551,7 +552,7 @@ contract('KyberNetwork', function(accounts) {
                 {from: tempStorage}
             );
             Helper.assertEqual(
-                new BN(2).pow(new BN(255)),
+                MAX_ALLOWANCE,
                 await token.allowance(tempNetwork.address, mockReserve.address)
             );
         });
@@ -662,7 +663,7 @@ contract('KyberNetwork', function(accounts) {
                 Helper.assertEqual(eventLogs.args.reserves.length, 1);
                 Helper.assertEqual(reserveAddresses[0], eventLogs.args.reserves[0]);
                 Helper.assertEqual(
-                    new BN(2).pow(new BN(255)),
+                    MAX_ALLOWANCE,
                     await token.allowance(tempNetwork.address, reserveAddresses[0])
                 );
                 // unlist reserves
@@ -711,7 +712,7 @@ contract('KyberNetwork', function(accounts) {
                 for(let i = 0; i < 1; i++) {
                     Helper.assertEqual(reserveAddresses[i], eventLogs.args.reserves[i]);
                     Helper.assertEqual(
-                        new BN(2).pow(new BN(255)),
+                        MAX_ALLOWANCE,
                         await token.allowance(tempNetwork.address, reserveAddresses[i])
                     );
                 }


### PR DESCRIPTION
When trying to list COMP token (compound) we found we can't use approve(2**255)

has this code in approve function:


function approve(address spender, uint rawAmount) external returns (bool) {
        uint96 amount;
        if (rawAmount == uint(-1)) {
            amount = uint96(-1);
        } else {
            amount = safe96(rawAmount, "Comp::approve: amount exceeds 96 bits");
        }

        allowances[msg.sender][spender] = amount;

        emit Approval(msg.sender, spender, amount);
        return true;
    }